### PR TITLE
Always show inactive content in the folder_contents view.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.1.5 (unreleased)
 ------------------
 
+- Always show inactive content in the folder_contents view.
+  This is part of a fix for https://dev.plone.org/ticket/8353.
+  [pbauer]
+
 - Allow modifying the pagesize by adding a request-string e.g. "?pagesize=100".
   [pbauer]
 

--- a/plone/app/content/browser/foldercontents.py
+++ b/plone/app/content/browser/foldercontents.py
@@ -119,6 +119,8 @@ class FolderContentsTable(object):
         self.context = context
         self.request = request
         self.contentFilter = contentFilter is not None and contentFilter or {}
+        if 'show_inactive' not in self.contentFilter:
+            self.contentFilter['show_inactive'] = True
         self.pagesize = int(self.request.get('pagesize', 20))
         self.items = self.folderitems()
         url = context.absolute_url()


### PR DESCRIPTION
This is part 2 of a possible fix for https://dev.plone.org/ticket/8353, part 1 is https://github.com/plone/Products.CMFPlone/pull/263
