### PR TITLE
fix removing tags with non-ascii characters in folder_contents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Changelog
 - Allow folderish types as default_page as long as users cannot add content
   to them.
   [pbauer]
-
+- fix removing tags with non-ascii characters in folder_contents
+  [petschki]
 
 3.0.1 (2014-10-23)
 ------------------

--- a/plone/app/content/browser/folder.py
+++ b/plone/app/content/browser/folder.py
@@ -326,8 +326,10 @@ class TagsAction(FolderContentsActionView):
     required_obj_permission = 'Modify portal content'
 
     def __call__(self):
-        self.remove = set(json.loads(self.request.form.get('remove')))
-        self.add = set(json.loads(self.request.form.get('add')))
+        self.remove = set([v.encode('utf8') for v in \
+            json.loads(self.request.form.get('remove'))])
+        self.add = set([v.encode('utf8') for v in \
+            json.loads(self.request.form.get('add'))])
         return super(TagsAction, self).__call__()
 
     def action(self, obj):


### PR DESCRIPTION
see also  https://github.com/collective/wildcard.foldercontents/pull/48 