### PR TITLE
Fix encoding problems with Mockup Select2 widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 3.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let ``@@getVocabulary`` return the vocabulary's value instead of the token
+  for the id in the result set. The token is binary encoded and leads to
+  encoding errors when selecting a value with non-ASCII data from vocabulary
+  list in a select2 based widget.
+  Fixes: https://github.com/plone/Products.CMFPlone/issues/650
+  [thet]
 
 
 3.0.6 (2015-06-05)

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -153,7 +153,7 @@ class BaseVocabularyView(BrowserView):
                 items.append(item)
         else:
             for item in results:
-                items.append({'id': item.token, 'text': item.title})
+                items.append({'id': item.value, 'text': item.title})
 
         if total == 0:
             total = len(items)

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -15,6 +15,7 @@ from plone.app.widgets.testing import ExampleFunctionVocabulary
 from plone.app.widgets.testing import ExampleVocabulary
 from plone.app.widgets.testing import PLONEAPPWIDGETS_INTEGRATION_TESTING
 from plone.app.widgets.testing import TestRequest
+from zope.component import getMultiAdapter
 from zope.component import provideAdapter
 from zope.component import provideUtility
 from zope.component.globalregistry import base
@@ -174,6 +175,29 @@ class BrowserTest(unittest.TestCase):
         data = json.loads(view())
         self.assertEquals(len(data['results']), 10)
         self.assertEquals(data['total'], amount)
+
+    def testVocabularyEncoding(self):
+        """The vocabulary should not return the binary encoded token
+        ("N=C3=A5=C3=B8=C3=AF"), but instead the value as the id in the result
+        set. Fixes an encoding problem. See:
+        https://github.com/plone/Products.CMFPlone/issues/650
+        """
+        test_val = u'Nåøï'
+
+        self.portal.invokeFactory('Document', id="page", title="page")
+        self.portal.page.subject = (test_val,)
+        self.portal.page.reindexObject(idxs=['Subject'])
+
+        self.request.form['name'] = 'plone.app.vocabularies.Keywords'
+        results = getMultiAdapter(
+            (self.portal, self.request),
+            name='getVocabulary'
+        )()
+        results = json.loads(results)
+        result = results['results'][0]
+
+        self.assertEquals(result['text'], test_val)
+        self.assertEquals(result['id'], test_val)
 
     def testVocabularyUnauthorized(self):
         setRoles(self.portal, TEST_USER_ID, [])


### PR DESCRIPTION
Let ``@@getVocabulary`` return the vocabulary's value instead of the token for the id in the result set. The token is binary encoded and leads to encoding errors when selecting a value with non-ASCII data from vocabulary list in a select2 based widget.  Fixes: https://github.com/plone/Products.CMFPlone/issues/650