### PR TITLE
Add portal_type to fc-contextInfo

### DIFF
--- a/plone/app/content/browser/folder.py
+++ b/plone/app/content/browser/folder.py
@@ -548,7 +548,7 @@ class ContextInfo(BrowserView):
                   'ModificationDate', 'EffectiveDate', 'CreationDate',
                   'is_folderish', 'Subject', 'getURL', 'id',
                   'exclude_from_nav', 'getObjSize', 'last_comment_date',
-                  'total_comments']
+                  'total_comments', 'portal_type']
 
     def __call__(self):
         factories_menu = getUtility(


### PR DESCRIPTION
Mockup's structure pattern expects portal_type as part of contextInfo where it
previously used Type.

Fixes #35 