### PR TITLE
Bugfix: allow deletion of items with unicode characters in the title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Changelog
 - When clicking cancel on the delete_confirmation got to the view_url.
   [ale-rt]
 
+- Fix deletion of objects with unicode charaters in the title.
+  [cillianderoiste]
+
 
 3.0.7 (2015-07-18)
 ------------------

--- a/plone/app/content/browser/actions.py
+++ b/plone/app/content/browser/actions.py
@@ -5,6 +5,7 @@ from Acquisition import aq_parent
 from OFS.CopySupport import CopyError
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
@@ -61,7 +62,7 @@ class DeleteConfirmationForm(form.Form, LockingBase):
 
     @button.buttonAndHandler(_(u'Delete'), name='Delete')
     def handle_delete(self, action):
-        title = self.context.Title()
+        title = safe_unicode(self.context.Title())
         parent = aq_parent(aq_inner(self.context))
 
         # has the context object been acquired from a place it should not have


### PR DESCRIPTION
To reproduce:
Create a folder with a unicode character in the title, and try to delete it via the @@delete_confirmation view. A UnicodeDecodeError is thrown on line 72.

The reason is that obj.Title() gives us a bytestring, but I'm not sure if we should just use the title attribute instead (as in this PR), or if there's a reason to use Title() and decode it before returning the status message.