### PR TITLE
fix tests: correct API usage to get the currently set default page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix tests: API usage to get default page in order to prevent side effects in
+  other tests.
+  [jensens]
 
 
 3.0.10 (2015-09-07)

--- a/plone/app/content/browser/contents/defaultpage.py
+++ b/plone/app/content/browser/contents/defaultpage.py
@@ -8,14 +8,14 @@ class SetDefaultPageActionView(ContentsBaseAction):
     failure_msg = _(u'Failed to set default page')
 
     def __call__(self):
-        id = self.request.form.get('id')
+        cid = self.request.form.get('id')
         self.errors = []
 
-        if id not in self.context.objectIds():
+        if cid not in self.context.objectIds():
             self.errors.append(
                 _(u'There is no object with short name '
                   u'${name} in this folder.',
-                  mapping={u'name': id}))
+                  mapping={u'name': cid}))
         else:
-            self.context.setDefaultPage(id)
+            self.context.setDefaultPage(cid)
         return self.message()

--- a/plone/app/content/tests/test_actions.py
+++ b/plone/app/content/tests/test_actions.py
@@ -221,7 +221,7 @@ class ActionsDXTestCase(unittest.TestCase):
         doc = folder['d1']
         folder.setDefaultPage('d1')
         transaction.commit()
-        self.assertEqual(folder.default_page, 'd1')
+        self.assertEqual(folder.getDefaultPage(), 'd1')
 
         # We need zope2.CopyOrMove permission to rename content
         self.browser.open(doc.absolute_url() + '/object_rename')
@@ -229,7 +229,7 @@ class ActionsDXTestCase(unittest.TestCase):
         self.browser.getControl(name='form.widgets.new_title').value = 'Doc'
         self.browser.getControl(name='form.buttons.Rename').click()
         self.assertEqual(folder.getFolderContents()[0].id, 'renamed')
-        self.assertEqual(folder.default_page, 'renamed')
+        self.assertEqual(folder.getDefaultPage(), 'renamed')
 
     def test_rename_form_cancel(self):
         folder = self.portal['f1']

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -205,7 +205,7 @@ class RenameTest(BaseTest):
         })
         view = RenameActionView(self.portal, self.request)
         view()
-        self.assertEqual(self.portal.default_page, 'page-renamed')
+        self.assertEqual(self.portal.getDefaultPage(), 'page-renamed')
 
 
 class ContextInfoTest(BaseTest):

--- a/plone/app/content/tests/test_selectdefaultpage.py
+++ b/plone/app/content/tests/test_selectdefaultpage.py
@@ -95,7 +95,7 @@ class SelectDefaultPageDXTestCase(unittest.TestCase):
         cancel_button.click()
 
         self.assertEqual(self.browser.url, folder.absolute_url())
-        self.assertFalse(hasattr(folder, 'default_page'))
+        self.assertIs(folder.getDefaultPage(), None)
 
     def test_default_page_action_save(self):
         """Check the Save action."""
@@ -106,7 +106,7 @@ class SelectDefaultPageDXTestCase(unittest.TestCase):
         submit_button.click()
 
         self.assertEqual(self.browser.url, folder.absolute_url())
-        self.assertEqual(folder.default_page, 'testdoc')
+        self.assertEqual(folder.getDefaultPage(), 'testdoc')
 
 
 class SelectDefaultPageATTestCase(SelectDefaultPageDXTestCase):


### PR DESCRIPTION
``folder.default_page`` is not an api and only works under certain circumstances. ``folder.getDefaultPage()`` is official api,