### PR TITLE
feat: allow the folder_contents options to be easily overwritten by s…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Refactor FolderContentsView to allow reasy overwriting of options.
+  [Gagaro]
 
 
 3.0.12 (2015-09-20)

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -143,7 +143,7 @@ class FolderContentsView(BrowserView):
         actions.sort(key=lambda a: a.order)
         return [a.get_options() for a in actions]
 
-    def __call__(self):
+    def get_options(self):
         site = getSite()
         base_url = site.absolute_url()
         base_vocabulary = '%s/@@getVocabulary?name=' % base_url
@@ -192,9 +192,12 @@ class FolderContentsView(BrowserView):
                 'baseUrl': base_url,
                 'initialFolder': IUUID(self.context, None),
                 'useTus': TUS_ENABLED
-            }
+            },
         }
-        self.options = json_dumps(options)
+        return options
+
+    def __call__(self):
+        self.options = json_dumps(self.get_options())
         return super(FolderContentsView, self).__call__()
 
 


### PR DESCRIPTION
…ubclasses

Hi,

This is to allow subclasses to easily overwrite default options. For example:

```python
class MyFolderContentsView(FolderContentsView):
    def get_options(self):
        options = super(MyFolderContentsView, self).get_options()
        options['foo'] = 'bar'
        return options
```