### PR TITLE
fix: allow unicode in object title when using actions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 - Refactor FolderContentsView to allow reasy overwriting of options.
+- Fix the actions to allow unicode in titles.
   [Gagaro]
 
 

--- a/plone/app/content/browser/actions.py
+++ b/plone/app/content/browser/actions.py
@@ -185,7 +185,7 @@ class ObjectCutView(LockingBase):
 
     @property
     def title(self):
-        return self.context.Title()
+        return self.context.Title().decode('utf8')
 
     @property
     def parent(self):

--- a/plone/app/content/tests/test_actions.py
+++ b/plone/app/content/tests/test_actions.py
@@ -33,7 +33,7 @@ class ActionsDXTestCase(unittest.TestCase):
 
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         self.portal.invokeFactory(
-            type_name='Folder', id='f1', title='A Test Folder')
+            type_name='Folder', id='f1', title=u'A Tést Folder')
 
         transaction.commit()
         self.browser = Browser(self.layer['app'])


### PR DESCRIPTION
With changelog entry and tests.