### PR TITLE
make @@getSource work for autocomplete widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Fixes:
   https://github.com/plone/Products.CMFPlone/issues/1226
   [fgrcon]
 
+- Fix @@getSource view to work with a text query
+  (as done by the ajax autocomplete widget)
+  in addition to a querystring widget query.
+  [davisagli]
+
 
 3.0.13 (2015-10-27)
 -------------------

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -2,7 +2,6 @@
 from AccessControl import getSecurityManager
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.layout.navigation.root import getNavigationRoot
-from Products.CMFPlone.utils import normalizeString
 from Products.Five import BrowserView
 from logging import getLogger
 from plone.app.content.utils import json_dumps
@@ -20,7 +19,6 @@ from zope.schema.interfaces import IVocabularyFactory
 from zope.security.interfaces import IPermission
 import inspect
 import itertools
-import os
 
 logger = getLogger(__name__)
 
@@ -170,8 +168,10 @@ class BaseVocabularyView(BrowserView):
         })
 
     def parsed_query(self, ):
-        query = _parseJSON(self.request.get('query', '')) or {}
-        if query:
+        query = _parseJSON(self.request.get('query', ''))
+        if isinstance(query, basestring):
+            query = {'SearchableText': {'query': query}}
+        elif query:
             parsed = queryparser.parseFormquery(
                 self.get_context(), query['criteria'])
             if 'sort_on' in query:
@@ -179,6 +179,8 @@ class BaseVocabularyView(BrowserView):
             if 'sort_order' in query:
                 parsed['sort_order'] = str(query['sort_order'])
             query = parsed
+        else:
+            query = {}
         return query
 
 

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -419,6 +419,33 @@ class BrowserTest(unittest.TestCase):
         data = json.loads(view())
         self.assertEquals(data['error'], 'Vocabulary lookup not allowed.')
 
+    def testSourceTextQuery(self):
+        from z3c.form.browser.text import TextWidget
+        from zope.interface import implementer
+        from zope.interface import Interface
+        from zope.schema import Choice
+        from zope.schema.interfaces import ISource
+
+        @implementer(ISource)
+        class DummyCatalogSource(object):
+            def search(self, query):
+                return [Mock(value=Mock(id=query))]
+
+        widget = TextWidget(self.request)
+        widget.context = self.portal
+        widget.field = Choice(source=DummyCatalogSource())
+        widget.field.interface = Interface
+
+        from plone.app.content.browser.vocabulary import SourceView
+        view = SourceView(widget, self.request)
+        self.request.form.update({
+            'query': 'foo',
+            'attributes': 'id',
+        })
+        data = json.loads(view())
+        self.assertEquals(len(data['results']), 1)
+        self.assertEquals(data['results'][0]['id'], 'foo')
+
     def testQueryStringConfiguration(self):
         view = QueryStringIndexOptions(self.portal, self.request)
         data = json.loads(view())


### PR DESCRIPTION
(The autocomplete widget sends a text query rather than a JSON-encoded querystring query.)

This is needed to work for sources that implement a `search` method but not `search_catalog`,
such as the UsersSource in plone.app.vocabularies.