### PR TITLE
Fix rearrange

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixed error message displaying during rearranging.
+  [Gagaro]
 
 
 3.0.14 (2015-11-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 New:
 
-- *add item here*
+- Ensure the base context allows ordering during rearranging.
+  [Gagaro]
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New:
 
 Fixes:
 
+- Fixed rearranging for archetypes.
+  [Gagaro]
+
 - Fixed error message displaying during rearranging.
   [Gagaro]
 

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -121,9 +121,9 @@ class ContentsBaseAction(BrowserView):
             translated_errors = [
                 translate(error, context=self.request) for error in self.errors
             ]
-            translated_msg = '{0:s}: {0:s}'.format(
+            translated_msg = u'{0:s}: {1:s}'.format(
                 translated_msg,
-                '\n'.join(translated_errors)
+                u'\n'.join(translated_errors)
             )
 
         return self.json({

--- a/plone/app/content/browser/contents/rearrange.py
+++ b/plone/app/content/browser/contents/rearrange.py
@@ -12,7 +12,10 @@ class OrderContentsBaseAction(ContentsBaseAction):
     def getOrdering(self):
         if IPloneSiteRoot.providedBy(self.context):
             return self.context
-        ordering = self.context.getOrdering()
+        try:
+            ordering = self.context.aq_base.getOrdering()
+        except AttributeError:
+            return None
         if not IExplicitOrdering.providedBy(ordering):
             return None
         return ordering

--- a/plone/app/content/browser/contents/rearrange.py
+++ b/plone/app/content/browser/contents/rearrange.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from OFS.interfaces import IOrderedContainer
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.utils import json_loads
 from plone.folder.interfaces import IExplicitOrdering
@@ -15,6 +16,9 @@ class OrderContentsBaseAction(ContentsBaseAction):
         try:
             ordering = self.context.aq_base.getOrdering()
         except AttributeError:
+            if IOrderedContainer.providedBy(self.context):
+                # Archetype
+                return IOrderedContainer(self.context)
             return None
         if not IExplicitOrdering.providedBy(ordering):
             return None


### PR DESCRIPTION
If the context does not have getOrdering, it will take the one from the parent folder. I have the issue with an archetype content type, I'm not sure how to get ordering right now, but this ensure it will not try to rearrange something else.

This PR also includes a fix to the error message generation. Tell me if you want me to split these commits.