### PR TITLE
fix: do not rename when only changing title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixed renaming when only changing title.
+  [Gagaro]
 
 
 3.0.15 (2015-12-15)


### PR DESCRIPTION
Not changing the id caused the id to become the old id with "-1" appended.