### PR TITLE
More available columns in folder_contents.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Add ``Creator``, ``Description``, ``end``, ``start`` and ``location`` to the available columns and context attributes for folder_contents.
+  Exclude ``Creator`` from the list of ``_unsafe_metadata``.
+  [thet]
 
 Fixes:
 

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -147,24 +147,27 @@ class FolderContentsView(BrowserView):
         # Base set of columns
         columns = {
             'CreationDate': translate(_('Created on'), context=self.request),  # noqa
+            'Creator': translate(_('Creator'), context=self.request),
+            'Description': translate(_('Description'), context=self.request),
             'EffectiveDate': translate(_('Publication date'), context=self.request),  # noqa
+            'end': translate(_('End Date'), context=self.request),
             'exclude_from_nav': translate(_('Excluded from navigation'), context=self.request),  # noqa
             'ExpirationDate': translate(_('Expiration date'), context=self.request),  # noqa
             'getObjSize': translate(_('Object Size'), context=self.request),  # noqa
             'id': translate(_('ID'), context=self.request),
             'is_folderish': translate(_('Folder'), context=self.request),
             'last_comment_date': translate(_('Last comment date'), context=self.request),  # noqa
+            'location': translate(_('Location'), context=self.request),
             'ModificationDate': translate(_('Last modified'), context=self.request),  # noqa
             'portal_type': translate(_('Type'), context=self.request),
             'review_state': translate(_('Review state'), context=self.request),  # noqa
+            'start': translate(_('Start Date'), context=self.request),
             'Subject': translate(_('Tags'), context=self.request),
             'total_comments': translate(_('Total comments'), context=self.request),  # noqa
         }
         # These columns either have alternatives or are probably not useful
         ignored = [
-            'Creator',
             'Date',
-            'Description',
             'Title',
             'Type',
             'author_name',
@@ -172,17 +175,14 @@ class FolderContentsView(BrowserView):
             'commentators',
             'created',
             'effective',
-            'end',
             'expires',
             'getIcon',
             'getId',
             'getRemoteUrl',
             'in_response_to',
             'listCreators',
-            'location',
             'meta_type',
             'modified',
-            'start',
             'sync_uid'
         ]
         # Add in extra metadata columns
@@ -244,22 +244,27 @@ class ContextInfo(BrowserView):
 
     attributes = [
         'CreationDate',
+        'Creator',
+        'Description',
         'EffectiveDate',
+        'end',
         'exclude_from_nav',
         'getObjSize',
         'getURL',
         'id',
         'is_folderish',
         'last_comment_date',
+        'location'
         'ModificationDate',
         'path',
         'portal_type',
         'review_state',
+        'start',
         'Subject',
         'Title',
         'total_comments',
         'Type',
-        'UID'
+        'UID',
     ]
 
     def __call__(self):

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -146,26 +146,43 @@ class FolderContentsView(BrowserView):
     def get_columns(self):
         # Base set of columns
         columns = {
-            'id': translate(_('ID'), context=self.request),
-            'ModificationDate': translate(_('Last modified'), context=self.request),  # noqa
-            'EffectiveDate': translate(_('Publication date'), context=self.request),  # noqa
-            'ExpirationDate': translate(_('Expiration date'), context=self.request),  #noqa
             'CreationDate': translate(_('Created on'), context=self.request),  # noqa
+            'EffectiveDate': translate(_('Publication date'), context=self.request),  # noqa
+            'exclude_from_nav': translate(_('Excluded from navigation'), context=self.request),  # noqa
+            'ExpirationDate': translate(_('Expiration date'), context=self.request),  # noqa
+            'getObjSize': translate(_('Object Size'), context=self.request),  # noqa
+            'id': translate(_('ID'), context=self.request),
+            'is_folderish': translate(_('Folder'), context=self.request),
+            'last_comment_date': translate(_('Last comment date'), context=self.request),  # noqa
+            'ModificationDate': translate(_('Last modified'), context=self.request),  # noqa
+            'portal_type': translate(_('Type'), context=self.request),
             'review_state': translate(_('Review state'), context=self.request),  # noqa
             'Subject': translate(_('Tags'), context=self.request),
-            'portal_type': translate(_('Type'), context=self.request),
-            'is_folderish': translate(_('Folder'), context=self.request),
-            'exclude_from_nav': translate(_('Excluded from navigation'), context=self.request),  # noqa
-            'getObjSize': translate(_('Object Size'), context=self.request),  # noqa
-            'last_comment_date': translate(_('Last comment date'), context=self.request),  # noqa
             'total_comments': translate(_('Total comments'), context=self.request),  # noqa
         }
         # These columns either have alternatives or are probably not useful
         ignored = [
-            'Creator', 'Date', 'Description', 'Title', 'Type', 'author_name',
-            'cmf_uid', 'commentators', 'created', 'effective', 'end',
-            'expires', 'getIcon', 'getId', 'getRemoteUrl', 'in_response_to',
-            'listCreators', 'location', 'meta_type', 'modified', 'start',
+            'Creator',
+            'Date',
+            'Description',
+            'Title',
+            'Type',
+            'author_name',
+            'cmf_uid',
+            'commentators',
+            'created',
+            'effective',
+            'end',
+            'expires',
+            'getIcon',
+            'getId',
+            'getRemoteUrl',
+            'in_response_to',
+            'listCreators',
+            'location',
+            'meta_type',
+            'modified',
+            'start',
             'sync_uid'
         ]
         # Add in extra metadata columns
@@ -195,7 +212,7 @@ class FolderContentsView(BrowserView):
             'contextInfoUrl': '%s{path}/@@fc-contextInfo' % base_url,
             'setDefaultPageUrl': '%s{path}/@@fc-setDefaultPage' % base_url,
             'availableColumns': columns,
-            'attributes': ['Title', 'path', 'getURL', 'getIcon'] + columns.keys(),
+            'attributes': ['Title', 'path', 'getURL', 'getIcon'] + columns.keys(),  # noqa
             'buttons': self.get_actions(),
             'rearrange': {
                 'properties': {
@@ -225,11 +242,25 @@ class FolderContentsView(BrowserView):
 
 class ContextInfo(BrowserView):
 
-    attributes = ['UID', 'Title', 'Type', 'path', 'review_state',
-                  'ModificationDate', 'EffectiveDate', 'CreationDate',
-                  'is_folderish', 'Subject', 'getURL', 'id',
-                  'exclude_from_nav', 'getObjSize', 'last_comment_date',
-                  'total_comments', 'portal_type']
+    attributes = [
+        'CreationDate',
+        'EffectiveDate',
+        'exclude_from_nav',
+        'getObjSize',
+        'getURL',
+        'id',
+        'is_folderish',
+        'last_comment_date',
+        'ModificationDate',
+        'path',
+        'portal_type',
+        'review_state',
+        'Subject',
+        'Title',
+        'total_comments',
+        'Type',
+        'UID'
+    ]
 
     def __call__(self):
         factories_menu = getUtility(

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -47,7 +47,6 @@ def _parseJSON(s):
 _unsafe_metadata = [
     'author_name',
     'commentors',
-    'Creator',
     'listCreators',
 ]
 _safe_callable_metadata = [

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -28,10 +28,10 @@ logger = getLogger(__name__)
 MAX_BATCH_SIZE = 500  # prevent overloading server
 
 _permissions = {
-    'plone.app.vocabularies.Users': 'Modify portal content',
     'plone.app.vocabularies.Catalog': 'View',
     'plone.app.vocabularies.Keywords': 'Modify portal content',
-    'plone.app.vocabularies.SyndicatableFeedItems': 'Modify portal content'
+    'plone.app.vocabularies.SyndicatableFeedItems': 'Modify portal content',
+    'plone.app.vocabularies.Users': 'Modify portal content',
 }
 
 
@@ -44,9 +44,19 @@ def _parseJSON(s):
     return s
 
 
-_unsafe_metadata = ['Creator', 'listCreators', 'author_name', 'commentors']
-_safe_callable_metadata = ['getURL', 'getPath','review_state',
-                            'getIcon', 'is_folderish']
+_unsafe_metadata = [
+    'author_name',
+    'commentors',
+    'Creator',
+    'listCreators',
+]
+_safe_callable_metadata = [
+    'getIcon',
+    'getPath',
+    'getURL',
+    'is_folderish',
+    'review_state',
+]
 
 
 class VocabLookupException(Exception):
@@ -135,12 +145,35 @@ class BaseVocabularyView(BrowserView):
             attributes = attributes.split(',')
 
         translate_ignored = [
-            'Creator', 'Date', 'Description', 'Title', 'author_name',
-            'cmf_uid', 'commentators', 'created', 'effective', 'end',
-            'expires', 'getIcon', 'getId', 'getRemoteUrl', 'in_response_to',
-            'listCreators', 'location', 'modified', 'start', 'sync_uid',
-            'path', 'getURL', 'EffectiveDate', 'getObjSize', 'id',
-            'UID', 'ExpirationDate', 'ModificationDate', 'CreationDate',
+            'author_name',
+            'cmf_uid',
+            'commentators',
+            'created',
+            'CreationDate',
+            'Creator',
+            'Date',
+            'Description',
+            'effective',
+            'EffectiveDate',
+            'end',
+            'ExpirationDate',
+            'expires',
+            'getIcon',
+            'getId',
+            'getObjSize',
+            'getRemoteUrl',
+            'getURL',
+            'id',
+            'in_response_to',
+            'listCreators',
+            'location',
+            'ModificationDate',
+            'modified',
+            'path',
+            'start',
+            'sync_uid',
+            'Title',
+            'UID',
         ]
         if attributes:
             base_path = getNavigationRoot(context)


### PR DESCRIPTION
- Add ``Creator``, ``Description``, ``end``, ``start`` and ``location`` to the available columns and context attributes for folder_contents.
- Exclude ``Creator`` from the list of ``_unsafe_metadata``.

IMO, these attributes can be handy for folder_contents listings.

@vangheem you added the ``_unsafe_metadata`` list of brain attributes, which should not be included in the ``@@getVocabulary`` view here: https://github.com/plone/plone.app.widgets/commit/5055725a2295422b1718ddbfe66d40870280d53a
Is this really necessary? IMO it would be handy to be able to list the author information in folder_contents.

We might want to exclude all attributes from the ``@@getVocabulary`` call, which are not shown as columns. But this has to be done for ``pat-structure`` in mockup.