### PR TITLE
Restore acquisition context in orderings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New:
 
 Fixes:
 
-- *add item here*
+- Restore acquisition context in orderings, which had been dropped by accident in 3.0.15 [pysailor]
 
 
 3.0.20 (2016-02-27)

--- a/plone/app/content/browser/contents/rearrange.py
+++ b/plone/app/content/browser/contents/rearrange.py
@@ -14,7 +14,10 @@ class OrderContentsBaseAction(ContentsBaseAction):
         if IPloneSiteRoot.providedBy(self.context):
             return self.context
         try:
-            ordering = self.context.aq_base.getOrdering()
+            if self.context.aq_base.getOrdering():
+                ordering = self.context.getOrdering()
+            else:
+                return None
         except AttributeError:
             if IOrderedContainer.providedBy(self.context):
                 # Archetype


### PR DESCRIPTION
In PR #66 from @Gagaro a fix was introduced to handle an issue with Archetypes in rearranging content. Thus probably by accident also the acquisition context for an `ordering` got removed (de00bd6).

However there are use cases when this acquisition context is needed, for example in an event handler for the `IContainerModifiedEvent` (which gets sent out after a rearrange operation).

This PR keeps the defensive strategy of #66, but the actual ordering gets a proper acquisition context again.