### PR TITLE
folder contents: fix breadcrumbs and toolbar for subsites and VH

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New:
 
 Fixes:
 
+- Fix folder contents path and breadcrumbs settings to show correct paths and render the toolbar correctly in navigation root subsites and virtual hosting environments pointing to subsites.
+  [thet]
+
 - Fix test isolation problem and remove an unnecessary test dependency on ``plone.app.widgets``.
   [thet]
 

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -11,17 +11,19 @@ from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone import utils
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five import BrowserView
+from urlparse import urlparse
 from zope.browsermenu.interfaces import IBrowserMenu
 from zope.component import getMultiAdapter
 from zope.component import getUtilitiesFor
 from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.component.interfaces import ISite
 from zope.i18n import translate
 from zope.interface import implementer
 
 import zope.deferredimport
+
 
 zope.deferredimport.deprecated(
     # remove in Plone 5.1
@@ -34,6 +36,30 @@ zope.deferredimport.deprecated(
     ItemOrder='plone.app.content.browser.content.rearrange:ItemOrderActionView',  # noqa
     Rearrange='plone.app.content.browser.content.rearrange:RearrangeOrderActionView',  # noqa
 )
+
+
+def get_top_site_from_url(context, request):
+    """Find the top-most site, which is in the url path.
+    For this given content structure:
+
+    /Plone/Subsite
+
+    It should return the following in these cases:
+
+    - Naked Plone without virtual hosting, /Plone: Plone
+    - Naked Plone without virtual hosting, /Plone/Subsite: Plone
+    - Virtual hosting which roots to the subsite: Subsite
+    """
+    url_path = urlparse(context.absolute_url()).path.split('/')
+
+    site = getSite()
+    for idx in range(len(url_path)):
+        _path = '/'.join(url_path[:idx + 1]) or '/'
+        site_path = request.physicalPathFromURL(_path)
+        site = context.restrictedTraverse('/'.join(site_path) or '/')
+        if ISite.providedBy(site):
+            break
+    return site
 
 
 class ContentsBaseAction(BrowserView):
@@ -177,7 +203,7 @@ class FolderContentsView(BrowserView):
         return columns
 
     def get_options(self):
-        site = getSite()
+        site = get_top_site_from_url(self.context, self.request)
         base_url = site.absolute_url()
         base_vocabulary = '%s/@@getVocabulary?name=' % base_url
         site_path = site.getPhysicalPath()
@@ -248,7 +274,8 @@ class ContextInfo(BrowserView):
 
         context = aq_inner(self.context)
         crumbs = []
-        while not IPloneSiteRoot.providedBy(context):
+        top_site = get_top_site_from_url(self.context, self.request)
+        while not context == top_site:
             crumbs.append({
                 'id': context.getId(),
                 'title': utils.pretty_title_or_id(context, context)

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -7,16 +7,18 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.dexterity.fti import DexterityFTI
+from plone.locking.interfaces import IRefreshableLockable
 from plone.protect.authenticator import createToken
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Testing.makerequest import makerequest
+from urlparse import urlparse
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.interface import alsoProvides
 from zope.publisher.browser import TestRequest
+
 import json
 import unittest
-from plone.locking.interfaces import IRefreshableLockable
 
 
 class BaseTest(unittest.TestCase):
@@ -41,6 +43,9 @@ class BaseTest(unittest.TestCase):
             }
         )
         self.request.REQUEST_METHOD = 'POST'
+        # Mock physicalPathFromURL
+        # NOTE: won't return the right path in virtual hosting environments
+        self.request.physicalPathFromURL = lambda url: urlparse(url).path.split('/')  # noqa
         alsoProvides(self.request, IAttributeAnnotatable)
         self.userList = 'one,two'
 


### PR DESCRIPTION
Fix folder contents path and breadcrumbs settings to show correct paths and render the toolbar correctly in navigation root subsites and virtual hosting environments pointing to subsites.

Folder contents should be navigatable through the whole site, even if a subsite is somewhere below IPloneSiteRoot. Being on that context, getSite() returned previously the subsite and folder_contents started to not properly display the breadcrumbs and could call @@render-toolbar, because it was called on a nonexistent context.
Finding the top-most ISite object, which is accessable within the URL path's boundaries, the structure pattern can handle this properly again.

/me not very proud of this code.

/cc @jensens 