### PR TITLE
More folder contents fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,16 +10,20 @@ Incompatibilities:
 
 New:
 
-- Add ``Creator``, ``Description``, ``end``, ``start`` and ``location`` to the available columns and context attributes for folder_contents.
+- Show attributes from ``_unsafe_metadata`` if user has "Modify Portal Content" permissions.
   [thet]
 
-  Show attributes from ``_unsafe_metadata`` if user has "Modify Portal Content" permissions.
+- Add ``Creator``, ``Description``, ``end``, ``start`` and ``location`` to the available columns and context attributes for folder_contents.
   [thet]
 
 Fixes:
 
-- Remove ``portal_type`` from available columns and use ``Type`` instead, which is meant to be read by humans.
-  ``portal_type`` is now available on the attributes object.
+- Folder contents: Acquire the top most visible portal object to operate on.
+  Fixes some issues in INavigationRoot or ISite based subsites and virtual hosting environments pointing to subsites.
+  Fixes include: show correct breadcrumb paths, paste to correct location.
+  [thet]
+
+  Fixes folder contents path and breadcrumbs settings to show correct paths and render the toolbar correctly in navigation root subsites and virtual hosting environments pointing to subsites.
   [thet]
 
 - Added most notably `portal_type`, `review_state` and `Subject` but also `exclude_from_nav`, `is_folderish`, `last_comment_date`, `meta_type` and `total_comments` to ``BaseVocabularyView`` ``translate_ignored`` list.
@@ -27,13 +31,14 @@ Fixes:
   Fixes https://github.com/plone/plone.app.content/issues/77
   [thet]
 
+- Remove ``portal_type`` from available columns and use ``Type`` instead, which is meant to be read by humans.
+  ``portal_type`` is now available on the attributes object.
+  [thet]
+
 - Vocabulary permissions are considered View permission by default, if not 
   stated different in PERMISSION global. Renamed _permissions to PERMISSIONS,
   Deprecated BBB name in place. Also minor code-style changes
   [jensens, thet]
-
-- Fix folder contents path and breadcrumbs settings to show correct paths and render the toolbar correctly in navigation root subsites and virtual hosting environments pointing to subsites.
-  [thet]
 
 - Fix test isolation problem and remove an unnecessary test dependency on ``plone.app.widgets``.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,9 +18,14 @@ New:
 
 Fixes:
 
+- Folder contents: When pasting, handle "Disallowed subobject type" ValueError and present a helpful error message.
+  Fixes: plone/mockup#657
+  [thet]
+
 - Folder contents: Acquire the top most visible portal object to operate on.
   Fixes some issues in INavigationRoot or ISite based subsites and virtual hosting environments pointing to subsites.
   Fixes include: show correct breadcrumb paths, paste to correct location.
+  Fixes: #86
   [thet]
 
   Fixes folder contents path and breadcrumbs settings to show correct paths and render the toolbar correctly in navigation root subsites and virtual hosting environments pointing to subsites.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,9 +28,6 @@ Fixes:
   Fixes: #86
   [thet]
 
-  Fixes folder contents path and breadcrumbs settings to show correct paths and render the toolbar correctly in navigation root subsites and virtual hosting environments pointing to subsites.
-  [thet]
-
 - Added most notably `portal_type`, `review_state` and `Subject` but also `exclude_from_nav`, `is_folderish`, `last_comment_date`, `meta_type` and `total_comments` to ``BaseVocabularyView`` ``translate_ignored`` list.
   Some of them are necessary for frontend logic and others cannot be translated.
   Fixes https://github.com/plone/plone.app.content/issues/77

--- a/plone/app/content/basecontent.rst
+++ b/plone/app/content/basecontent.rst
@@ -4,6 +4,7 @@ Basic content
 
 plone.app.content provides some helper base classes for content. Here are
 some simple examples of using them.
+.. code-block:: python
 
     >>> from plone.app.content import container, item
 
@@ -15,12 +16,14 @@ available from Plone's "add item" menu. Factories are registered as named
 utilities.
 
 Note that we need to define a portal_type to keep CMF happy.
+.. code-block:: python
 
     >>> from zope.interface import implements, Interface
     >>> from zope import schema
     >>> from zope.component.factory import Factory
 
 First, a container:
+.. code-block:: python
 
     >>> class IMyContainer(Interface):
     ...     title = schema.TextLine(title=u"My title")
@@ -35,6 +38,7 @@ First, a container:
     >>> containerFactory = Factory(MyContainer)
 
 Then, an item:
+.. code-block:: python
 
     >>> class IMyType(Interface):
     ...     title = schema.TextLine(title=u"My title")
@@ -49,6 +53,7 @@ Then, an item:
     >>> itemFactory = Factory(MyType)
 
 We can now create the items.
+.. code-block:: python
 
     >>> container = containerFactory("my-container")
     >>> container.id
@@ -56,11 +61,13 @@ We can now create the items.
     >>> container.title = "A sample container"
 
 We need to add it to an object manager for acquisition to do its magic.
+.. code-block:: python
 
     >>> newid = self.portal._setObject(container.id, container)
     >>> container = getattr(self.portal, newid)
 
 We will add the item directly to the container later.
+.. code-block:: python
 
     >>> item = itemFactory("my-item")
     >>> item.id
@@ -70,6 +77,7 @@ We will add the item directly to the container later.
 Note that both the container type and the item type are contentish. This is
 important, because CMF provides event handlers that automatically index
 objects that are IContentish.
+.. code-block:: python
 
     >>> from Products.CMFCore.interfaces import IContentish
     >>> IContentish.providedBy(container)
@@ -78,6 +86,7 @@ objects that are IContentish.
     True
 
 Only the container is folderish, though:
+.. code-block:: python
 
     >>> from Products.CMFCore.interfaces import IFolderish
     >>> bool(container.isPrincipiaFolderish)
@@ -91,6 +100,7 @@ Only the container is folderish, though:
 
 We can use the more natural Zope3-style container API, or the traditional
 ObjectManager one.
+.. code-block:: python
 
     >>> container['my-item'] = item
     >>> 'my-item' in container
@@ -106,6 +116,7 @@ ObjectManager one.
     True
 
 Both pieces of content should have been cataloged.
+.. code-block:: python
 
     >>> container = self.portal['my-container']
     >>> item = container['my-item']
@@ -118,6 +129,7 @@ Both pieces of content should have been cataloged.
     ['A non-folderish item']
 
 If we modify an object and trigger a modified event, it should be updated.
+.. code-block:: python
 
     >>> from zope.lifecycleevent import ObjectModifiedEvent
     >>> from zope.event import notify

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -163,7 +163,7 @@ class ContentsBaseAction(BrowserView):
             )
 
         return self.json({
-            'status': 'success',
+            'status': 'warning' if self.errors else 'success',
             'msg': translated_msg
         })
 

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -68,6 +68,10 @@ class ContentsBaseAction(BrowserView):
     failure_msg = _('Failure')
     required_obj_permission = None
 
+    @property
+    def site(self):
+        return get_top_site_from_url(self.context, self.request)
+
     def objectTitle(self, obj):
         context = aq_inner(obj)
         title = utils.pretty_title_or_id(context, context)
@@ -100,11 +104,10 @@ class ContentsBaseAction(BrowserView):
     def __call__(self):
         self.protect()
         self.errors = []
-        site = getSite()
         context = aq_inner(self.context)
         selection = self.get_selection()
 
-        self.dest = site.restrictedTraverse(
+        self.dest = self.site.restrictedTraverse(
             str(self.request.form['folder'].lstrip('/')))
 
         self.catalog = getToolByName(context, 'portal_catalog')

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -39,7 +39,14 @@ zope.deferredimport.deprecated(
 
 
 def get_top_site_from_url(context, request):
-    """Find the top-most site, which is in the url path.
+    """Find the top-most site, which is still in the url path.
+
+    If the current context is within a subsite within a PloneSiteRoot and no
+    virtual hosting is in place, the PloneSiteRoot is returned.
+    When at the same context but in a virtual hosting environment with the
+    virtual host root pointing to the subsites, it returns the subsite instead
+    of the PloneSiteRoot.
+
     For this given content structure:
 
     /Plone/Subsite

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -49,5 +49,13 @@ class PasteActionView(ContentsBaseAction):
             self.errors.append(
                 _(u'You are not authorized to paste ${title} here.',
                     mapping={u'title': self.objectTitle(self.dest)}))
+        except ValueError as e:
+            if 'Disallowed subobject type: ' in e.message:
+                msg_parts = e.message.split(':')
+                self.errors.append(
+                    _(u'Disallowed subobject type: ${type}',
+                        mapping={u'type': msg_parts[1].strip()}))
+            else:
+                raise e
 
         return self.message()

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -53,7 +53,7 @@ class PasteActionView(ContentsBaseAction):
             if 'Disallowed subobject type: ' in e.message:
                 msg_parts = e.message.split(':')
                 self.errors.append(
-                    _(u'Disallowed subobject type: ${type}',
+                    _(u'Disallowed subobject type "${type}"',
                         mapping={u'type': msg_parts[1].strip()}))
             else:
                 raise e

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -4,7 +4,6 @@ from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFPlone import PloneMessageFactory as _
 from ZODB.POSException import ConflictError
-from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implementer
 
@@ -35,9 +34,8 @@ class PasteActionView(ContentsBaseAction):
     def __call__(self):
         self.protect()
         self.errors = []
-        site = getSite()
 
-        self.dest = site.restrictedTraverse(
+        self.dest = self.site.restrictedTraverse(
             str(self.request.form['folder'].lstrip('/')))
 
         try:

--- a/plone/app/content/browser/contents/properties.py
+++ b/plone/app/content/browser/contents/properties.py
@@ -21,9 +21,7 @@ class PropertiesAction(object):
         self.request = request
 
     def get_options(self):
-        site = getSite()
-        base_url = site.absolute_url()
-        base_vocabulary = '%s/@@getVocabulary?name=' % base_url
+        base_vocabulary = '%s/@@getVocabulary?name=' % getSite().absolute_url()
         return {
             'title': translate(_('Properties'), context=self.request),
             'id': 'properties',
@@ -34,7 +32,7 @@ class PropertiesAction(object):
                 'template': self.template(
                     vocabulary_url='%splone.app.vocabularies.Users' % (
                         base_vocabulary)
-                    )
+                )
             }
         }
 

--- a/plone/app/content/browser/contents/tags.py
+++ b/plone/app/content/browser/contents/tags.py
@@ -19,9 +19,7 @@ class TagsAction(object):
         self.request = request
 
     def get_options(self):
-        site = getSite()
-        base_url = site.absolute_url()
-        base_vocabulary = '%s/@@getVocabulary?name=' % base_url
+        base_vocabulary = '%s/@@getVocabulary?name=' % getSite().absolute_url()
         return {
             'title': translate(_('Tags'), context=self.request),
             'id': 'tags',
@@ -31,7 +29,7 @@ class TagsAction(object):
                 'template': self.template(
                     vocabulary_url='%splone.app.vocabularies.Keywords' % (
                         base_vocabulary)
-                    )
+                )
             }
         }
 

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -31,6 +31,7 @@ logger = getLogger(__name__)
 MAX_BATCH_SIZE = 500  # prevent overloading server
 
 DEFAULT_PERMISSION = 'View'
+DEFAULT_PERMISSION_SECURE = 'Modify portal content'
 PERMISSIONS = {
     'plone.app.vocabularies.Catalog': 'View',
     'plone.app.vocabularies.Keywords': 'Modify portal content',
@@ -193,7 +194,7 @@ class BaseVocabularyView(BrowserView):
         if attributes:
             base_path = getNavigationRoot(context)
             sm = getSecurityManager()
-            can_edit = sm.checkPermission('Modify portal content', context)
+            can_edit = sm.checkPermission(DEFAULT_PERMISSION_SECURE, context)
             for vocab_item in results:
                 if not results_are_brains:
                     vocab_item = vocab_item.value

--- a/plone/app/content/tests/test_basecontent.py
+++ b/plone/app/content/tests/test_basecontent.py
@@ -8,7 +8,7 @@ import unittest
 def test_suite():
     return unittest.TestSuite((
         ztc.ZopeDocFileSuite(
-            'basecontent.txt',
+            'basecontent.rst',
             package='plone.app.content',
             test_class=ContentFunctionalTestCase,
             optionflags=(doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)),

--- a/plone/app/content/tests/test_contents.py
+++ b/plone/app/content/tests/test_contents.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+
+class ContentsUnitTests(unittest.TestCase):
+
+    def test_get_top_site_from_url(self):
+        """Unit test for ``get_top_site_from_url`` with context and request
+        mocks.
+
+        Test content structure:
+        /approot/PloneSite/folder/SubSite/folder
+        PloneSite and SubSite implement ISite
+        """
+        from plone.app.content.browser.contents import get_top_site_from_url
+        from zope.component.interfaces import ISite
+        from zope.interface import alsoProvides
+        from urlparse import urlparse
+
+        class MockContext(object):
+            vh_url = 'http://nohost'
+            vh_root = ''
+
+            def __init__(self, physical_path):
+                self.physical_path = physical_path
+                if self.physical_path.split('/')[-1] in ('PloneSite', 'SubSite'):  # noqa
+                    alsoProvides(self, ISite)
+
+            @property
+            def id(self):
+                return self.physical_path.split('/')[-1]
+
+            def absolute_url(self):
+                return self.vh_url + self.physical_path[len(self.vh_root):] or '/'  # noqa
+
+            def restrictedTraverse(self, path):
+                return MockContext(self.vh_root + path)
+
+        class MockRequest(object):
+            vh_url = 'http://nohost'
+            vh_root = ''
+
+            def physicalPathFromURL(self, url):
+                # Return the physical path from a URL.
+                # The outer right '/' is not part of the path.
+                path = self.vh_root + urlparse(url).path.rstrip('/')
+                return path.split('/')
+
+        # NO VIRTUAL HOSTING
+
+        req = MockRequest()
+
+        # Case 1:
+        ctx = MockContext('/approot/PloneSite')
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'PloneSite')
+
+        # Case 2
+        ctx = MockContext('/approot/PloneSite/folder')
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'PloneSite')
+
+        # Case 3:
+        ctx = MockContext('/approot/PloneSite/folder/SubSite/folder')
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'PloneSite')
+
+        # VIRTUAL HOSTING ON SUBSITE
+
+        req = MockRequest()
+        req.vh_root = '/approot/PloneSite/folder/SubSite'
+
+        # Case 4:
+        ctx = MockContext('/approot/PloneSite/folder/SubSite')
+        ctx.vh_root = '/approot/PloneSite/folder/SubSite'
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'SubSite')
+
+        # Case 5:
+        ctx = MockContext('/approot/PloneSite/folder/SubSite/folder')
+        ctx.vh_root = '/approot/PloneSite/folder/SubSite'
+        self.assertEqual(get_top_site_from_url(ctx, req).id, 'SubSite')

--- a/plone/app/content/tests/test_contents.py
+++ b/plone/app/content/tests/test_contents.py
@@ -1,4 +1,13 @@
 # -*- coding: utf-8 -*-
+from plone.app.content.testing import PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.dexterity.fti import DexterityFTI
+
+import json
+import mock
 import unittest
 
 
@@ -76,3 +85,71 @@ class ContentsUnitTests(unittest.TestCase):
         ctx = MockContext('/approot/PloneSite/folder/SubSite/folder')
         ctx.vh_root = '/approot/PloneSite/folder/SubSite'
         self.assertEqual(get_top_site_from_url(ctx, req).id, 'SubSite')
+
+
+class ContentsPasteTests(unittest.TestCase):
+    layer = PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        # TYPE 1
+        type1_fti = DexterityFTI('type1')
+        type1_fti.klass = 'plone.dexterity.content.Container'
+        type1_fti.filter_content_types = True
+        type1_fti.allowed_content_types = ['type1']
+        type1_fti.behaviors = (
+            'Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes',  # noqa
+            'plone.app.dexterity.behaviors.metadata.IBasic'
+        )
+        self.portal.portal_types._setObject('type1', type1_fti)
+        self.type1_fti = type1_fti
+
+        login(self.portal, TEST_USER_NAME)
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        self.portal.invokeFactory('type1', id='it1', title='Item 1')
+
+    @mock.patch('plone.app.content.browser.contents.ContentsBaseAction.protect', lambda x: True)  # noqa
+    def test_paste_success(self):
+        """Copy content item and paste in portal root.
+        """
+        # # setup copying via @@fc-copy
+        # from plone.uuid.interfaces import IUUID
+        # self.request['selection'] = [IUUID(self.portal.it1)]
+        # self.portal.restrictedTraverse('@@fc-copy')()
+
+        self.request['__cp'] = self.portal.manage_copyObjects(['it1'])
+        self.request.form['folder'] = '/'
+        res = self.portal.restrictedTraverse('@@fc-paste')()
+
+        res = json.loads(res)
+        self.assertEqual(res['status'], 'success')
+        self.assertEqual(len(self.portal.contentIds()), 2)
+
+    @mock.patch('plone.app.content.browser.contents.ContentsBaseAction.protect', lambda x: True)  # noqa
+    def test_paste_success_paste_in_itself(self):
+        """Copy content item and paste in itself. Because we can.
+        """
+        self.request['__cp'] = self.portal.manage_copyObjects(['it1'])
+        self.request.form['folder'] = '/it1'
+        res = self.portal.it1.restrictedTraverse('@@fc-paste')()
+
+        res = json.loads(res)
+        self.assertEqual(res['status'], 'success')
+        self.assertEqual(len(self.portal.it1.contentIds()), 1)
+
+    @mock.patch('plone.app.content.browser.contents.ContentsBaseAction.protect', lambda x: True)  # noqa
+    def test_paste_fail_constraint(self):
+        """Fail pasting content item in itself when folder constraints don't
+        allow to.
+        """
+        self.type1_fti.allowed_content_types = []  # set folder constraints
+        self.request['__cp'] = self.portal.manage_copyObjects(['it1'])
+        self.request.form['folder'] = '/it1'
+        res = self.portal.it1.restrictedTraverse('@@fc-paste')()
+
+        res = json.loads(res)
+        self.assertEqual(res['status'], 'warning')
+        self.assertEqual(len(self.portal.it1.contentIds()), 0)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         test=[
             'plone.app.contenttypes',
             'plone.app.testing',
+            'mock'
         ]
     ),
     install_requires=[


### PR DESCRIPTION
- Folder contents: Acquire the top most visible portal object to operate on.
Fixes some issues in INavigationRoot or ISite based subsites and virtual hosting environments pointing to subsites.
Fixes include: show correct breadcrumb paths, paste to correct location.
Fixes: #86 

- Folder contents: When pasting, handle "Disallowed subobject type" ValueError and present a helpful error message.
Fixes: plone/mockup#657
