### PR TITLE
allowUpload JSON view, content-type json for all

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Breaking changes:
 
 New features:
 
+- Add ``@@allowed_types_in_context`` JSON view in ``plone.app.content.browser.allowed_types_in_context``, which returns a list of all FTI ids, which can be added in the current container.
+  [thet]
+
 - Factor out the available columns ignored list which can be used to narrow down the available columns list to a user friendly set.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Breaking changes:
 
 New features:
 
-- Add ``@@allowed_types_in_context`` JSON view in ``plone.app.content.browser.allowed_types_in_context``, which returns a list of all FTI ids, which can be added in the current container.
+- Add ``@@allow_upload`` view, which returns a JSON string to indicate if File or Image uploads are allowed in the current container.
   [thet]
 
 - Factor out the available columns ignored list which can be used to narrow down the available columns list to a user friendly set.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New features:
 
 Bug fixes:
 
+- Explicitly set ``application/json`` content type for JSON responses and declare an ``utf-8`` charset.
+  [thet]
+
 - Properly deprecated ``_permissions`` in favor of ``PERMISSIONS``.
   Since 3.1, the ``_permissions`` variable was ``None`` instead of a
   backwards compatibility alias for ``PERMISSIONS`` due to a wrong

--- a/plone/app/content/browser/__init__.py
+++ b/plone/app/content/browser/__init__.py
@@ -1,1 +1,17 @@
 # -*- coding: utf-8 -*-
+from Products.Five.browser import BrowserView
+import json
+
+
+class AllowedTypesInContext(BrowserView):
+
+    def __call__(self):
+        """Return JSON structure with all allowed content type ids from the
+        current container.
+        """
+
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
+        allowed_types = [t.getId() for t in self.context.allowedContentTypes()]
+        return json.dumps({'allowed_types': allowed_types})

--- a/plone/app/content/browser/__init__.py
+++ b/plone/app/content/browser/__init__.py
@@ -1,17 +1,1 @@
 # -*- coding: utf-8 -*-
-from Products.Five.browser import BrowserView
-import json
-
-
-class AllowedTypesInContext(BrowserView):
-
-    def __call__(self):
-        """Return JSON structure with all allowed content type ids from the
-        current container.
-        """
-
-        self.request.response.setHeader(
-            'Content-Type', 'application/json; charset=utf-8'
-        )
-        allowed_types = [t.getId() for t in self.context.allowedContentTypes()]
-        return json.dumps({'allowed_types': allowed_types})

--- a/plone/app/content/browser/configure.zcml
+++ b/plone/app/content/browser/configure.zcml
@@ -180,11 +180,10 @@
         permission="zope2.View"
         />
 
-    <!-- ajax views -->
     <browser:page
         for="*"
-        name="allowed_types_in_context"
-        class=".AllowedTypesInContext"
+        name="allow_upload"
+        class=".file.AllowUploadView"
         permission="cmf.AddPortalContent"
         />
 

--- a/plone/app/content/browser/configure.zcml
+++ b/plone/app/content/browser/configure.zcml
@@ -180,4 +180,12 @@
         permission="zope2.View"
         />
 
+    <!-- ajax views -->
+    <browser:page
+        for="*"
+        name="allowed_types_in_context"
+        class=".AllowedTypesInContext"
+        permission="cmf.AddPortalContent"
+        />
+
 </configure>

--- a/plone/app/content/browser/constraintypes.py
+++ b/plone/app/content/browser/constraintypes.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
+from plone.autoform.form import AutoExtensibleForm
 from Products.CMFPlone import PloneMessageFactory as PC_
 from Products.CMFPlone.interfaces import ISelectableConstrainTypes
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.autoform.form import AutoExtensibleForm
 from z3c.form import button
 from z3c.form import form
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.interface import invariant
 from zope.interface.exceptions import Invalid
 from zope.schema import Choice
@@ -15,6 +15,7 @@ from zope.schema import List
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+
 
 # XXX
 # acquire locallyAllowedTypes from parent (default)

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -92,7 +92,9 @@ class ContentsBaseAction(BrowserView):
         checkpost(self.request)
 
     def json(self, data):
-        self.request.response.setHeader("Content-Type", "application/json")
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
         return json_dumps(data)
 
     def get_selection(self):
@@ -283,6 +285,9 @@ class FolderContentsView(BrowserView):
         return options
 
     def __call__(self):
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
         self.options = json_dumps(self.get_options())
         return super(FolderContentsView, self).__call__()
 
@@ -360,6 +365,10 @@ class ContextInfo(BrowserView):
                 if key == 'path':
                     val = val[len(base_path):]
                 item[key] = val
+
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
         return json_dumps({
             'addButtons': factories,
             'defaultPage': self.context.getDefaultPage(),

--- a/plone/app/content/browser/contents/delete.py
+++ b/plone/app/content/browser/contents/delete.py
@@ -54,7 +54,9 @@ class DeleteActionView(ContentsBaseAction):
             catalog = getToolByName(self.context, 'portal_catalog')
             brains = catalog(UID=selection)
             items = [i.getObject() for i in brains]
-            self.request.response.setHeader('Content-Type', 'application/json')
+            self.request.response.setHeader(
+                'Content-Type', 'application/json; charset=utf-8'
+            )
             return json.dumps({
                 'html': confirm_view(items)
             })

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.permissions import AddPortalContent
-from Products.Five.browser import BrowserView
 from plone.app.dexterity.interfaces import IDXFileFactory
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.permissions import AddPortalContent
+from Products.Five.browser import BrowserView
+
 import json
 import logging
 import mimetypes
 import os
+
 
 logger = logging.getLogger('plone')
 

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -194,3 +194,22 @@ class FileUploadView(BrowserView):
             'Content-Type', 'application/json; charset=utf-8'
         )
         return json.dumps(result)
+
+
+class AllowUploadView(BrowserView):
+
+    def __call__(self):
+        """Return JSON structure to indicate if File or Image uploads are
+        allowed in the current container.
+        """
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
+        allowed_types = [t.getId() for t in self.context.allowedContentTypes()]
+        allow_images = u'Image' in allowed_types
+        allow_files = u'File' in allowed_types
+        return json.dumps({
+            'allowUpload': allow_images or allow_files,
+            'allowImages': allow_images,
+            'allowFiles': allow_files
+        })

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -187,4 +187,8 @@ class FileUploadView(BrowserView):
             'UID': IUUID(obj),
             'filename': filename
         })
+
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
         return json.dumps(result)

--- a/plone/app/content/browser/i18n.py
+++ b/plone/app/content/browser/i18n.py
@@ -38,6 +38,6 @@ class i18njs(BrowserView):
 
         catalog = self._gettext_catalog(domain, language)
         response = self.request.response
-        response.setHeader('content-type', 'application/json')
+        response.setHeader('Content-Type', 'application/json; charset=utf-8')
         response.setBody(json.dumps(catalog))
         return response

--- a/plone/app/content/browser/query.py
+++ b/plone/app/content/browser/query.py
@@ -11,5 +11,7 @@ class QueryStringIndexOptions(BrowserView):
     def __call__(self):
         registry = getUtility(IRegistry)
         config = IQuerystringRegistryReader(registry)()
-        self.request.response.setHeader("Content-Type", "application/json")
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
         return json.dumps(config)

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -93,7 +93,9 @@ class BaseVocabularyView(BrowserView):
         }
         """
         context = self.get_context()
-        self.request.response.setHeader("Content-type", "application/json")
+        self.request.response.setHeader(
+            'Content-Type', 'application/json; charset=utf-8'
+        )
 
         try:
             vocabulary = self.get_vocabulary()

--- a/plone/app/content/tests/test_contents.py
+++ b/plone/app/content/tests/test_contents.py
@@ -153,3 +153,48 @@ class ContentsPasteTests(unittest.TestCase):
         res = json.loads(res)
         self.assertEqual(res['status'], 'warning')
         self.assertEqual(len(self.portal.it1.contentIds()), 0)
+
+
+class AllowedTypesInContextTests(unittest.TestCase):
+    layer = PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        # TYPE 1
+        type1_fti = DexterityFTI('type1')
+        type1_fti.klass = 'plone.dexterity.content.Container'
+        type1_fti.filter_content_types = True
+        type1_fti.allowed_content_types = ['type1']
+        type1_fti.behaviors = (
+            'Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes',  # noqa
+            'plone.app.dexterity.behaviors.metadata.IBasic'
+        )
+        self.portal.portal_types._setObject('type1', type1_fti)
+        self.type1_fti = type1_fti
+
+        login(self.portal, TEST_USER_NAME)
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        self.portal.invokeFactory('type1', id='it1', title='Item 1')
+
+    def test_allowed_types_in_context_view(self):
+
+        # Test root object
+        allowed_types = self.portal.restrictedTraverse('@@allowed_types_in_context')  # noqa
+        allowed_types = json.loads(allowed_types())
+
+        self.assertEqual(
+            sorted(allowed_types['allowed_types']),
+            [u'Collection', u'Document', u'Event', u'File', u'Folder', u'Image', u'Link', u'News Item', u'type1']  # noqa
+        )
+
+        # Test subfolder
+        allowed_types = self.portal.it1.restrictedTraverse('@@allowed_types_in_context')  # noqa
+        allowed_types = json.loads(allowed_types())
+
+        self.assertEqual(
+            sorted(allowed_types['allowed_types']),
+            [u'type1']
+        )


### PR DESCRIPTION
- Add ``@@allow_upload`` view, which returns a JSON string to indicate if File or Image uploads are allowed in the current container.

- Explicitly set ``application/json`` content type for JSON responses and declare an ``utf-8`` charset.