### PR TITLE
folder contents properties fix + rename images scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ Bug fixes:
 
 New features:
 
+- In the rename dialog, show image thumbnails in ``thumb`` scale instead of ``icon``.
+  Plones standard ``icon`` scale is way to small to be useful for images.
+  [thet]
+
 - Add ``@@allow_upload`` view, which returns a JSON string to indicate if File or Image uploads are allowed in the current container.
   When the view is called with a ``path`` request parameter, then content at this path is used instead the content where the view is called.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,14 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Folder contents rename dialog: In the rename dialog, show image thumbnails in ``thumb`` scale instead of ``icon``.
+  Plones standard ``icon`` scale is way to small to be useful for images.
+  [thet]
 
 Bug fixes:
+
+- Folder contents properties dialog: Fix form request variables for ``effectiveDate`` and ``expirationDate`` dates.
+  [thet]
 
 - Fix a json "circular reference detected" error which happened when the json dumper got unparsable data types.
   [pcdummy]
@@ -22,10 +27,6 @@ Bug fixes:
 ----------------
 
 New features:
-
-- In the rename dialog, show image thumbnails in ``thumb`` scale instead of ``icon``.
-  Plones standard ``icon`` scale is way to small to be useful for images.
-  [thet]
 
 - Add ``@@allow_upload`` view, which returns a JSON string to indicate if File or Image uploads are allowed in the current container.
   When the view is called with a ``path`` request parameter, then content at this path is used instead the content where the view is called.

--- a/plone/app/content/browser/contents/templates/properties.pt
+++ b/plone/app/content/browser/contents/templates/properties.pt
@@ -1,11 +1,11 @@
 <div i18n:domain="plone">
   <div class="form-group">
     <label i18n:translate="publiciation_date">Publication Date</label>
-    <input class="form-control pat-pickadate" name="effective" />
+    <input class="form-control pat-pickadate" name="effectiveDate" />
   </div>
   <div class="form-group">
     <label i18n:translate="expiration_date">Expiration Date</label>
-    <input class="form-control pat-pickadate" name="expiration" />
+    <input class="form-control pat-pickadate" name="expirationDate" />
   </div>
   <div class="form-group">
     <label i18n:translate="copyright">Copyright</label>

--- a/plone/app/content/browser/contents/templates/rename.pt
+++ b/plone/app/content/browser/contents/templates/rename.pt
@@ -1,16 +1,17 @@
 <div class="itemstoremove" i18n:domain="plone">
 <% _.each(items, function(item, index) { %>
   <div class="item">
-  	<% if(item.getIcon ){ %><img class="image-icon" src="<%= item.getURL %>/@@images/image/icon"><% } %>
-    <div class="form-group">
 
+    <div class="form-group">
       <input name="UID_<%= index %>" type="hidden" value="<%- item.UID %>" />
       <label i18n:translate="label_title">Title</label>
       <input class="form-control" name="newtitle_<%= index %>" value="<%= item.Title %>" />
       <label i18n:translate="label_short_name">Short name</label>
       <input class="form-control" name="newid_<%= index %>" value="<%= item.id %>" />
-
     </div>
+
+    <% if(item.getIcon ){ %><img class="image-thumb" src="<%= item.getURL %>/@@images/image/thumb"><% } %>
+
   </div>
 <% }) %>
 </div>


### PR DESCRIPTION
- Folder contents properties dialog: Fix form request variables for ``effective`` and ``expiration`` dates.

- Folder contents rename dialog: In the rename dialog, show image thumbnails in ``thumb`` scale instead of ``icon``. Plones standard ``icon`` scale is way to small to be useful for images.

Part of: https://github.com/plone/mockup/pull/696