### PR TITLE
Fix a circular reference error in the json dumper.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix a json "circular reference detected" error which happened when the json dumper got unparsable data types.
+  [pcdummy]
 
 
 3.2 (2016-08-18)

--- a/plone/app/content/utils.py
+++ b/plone/app/content/utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from DateTime import DateTime
+
 import Missing
 import datetime
 import json
@@ -9,6 +11,11 @@ def custom_json_handler(obj):
         return None
     if type(obj) in (datetime.datetime, datetime.date):
         return obj.isoformat()
+    if type(obj) == DateTime:
+        dt = DateTime(obj)
+        return dt.ISO()
+    if type(obj) == set:
+        return list(obj)
     return obj
 
 


### PR DESCRIPTION
Somehow on one of our clients Website we get that error on "folder_listing",
"circular reference" happens when json_dumps gets a unparseable data type.

Other people also have this error:
https://community.plone.org/t/problem-with-listing-folder-content/2271/4

Signed-off-by: Rene Jochum <rene@jochums.at>