### PR TITLE
Fix get_top_site_from_url, Issue #103.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix issue with ``get_top_site_from_url``, where in some circumstances a ValueError was thrown.
+  If that happens, just return ``getSite``.
+  You will only notice, if you have subsites, access them non-VirtualHost-rooted and an error is thrown.
+  Then folder contents won't be able to navigate up to the root Plone site.
+  [thet]
 
 
 3.3.1 (2016-09-23)

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -60,12 +60,17 @@ def get_top_site_from_url(context, request):
     url_path = urlparse(context.absolute_url()).path.split('/')
 
     site = getSite()
-    for idx in range(len(url_path)):
-        _path = '/'.join(url_path[:idx + 1]) or '/'
-        site_path = request.physicalPathFromURL(_path)
-        site = context.restrictedTraverse('/'.join(site_path) or '/')
-        if ISite.providedBy(site):
-            break
+    try:
+        for idx in range(len(url_path)):
+            _path = '/'.join(url_path[:idx + 1]) or '/'
+            site_path = request.physicalPathFromURL(_path)
+            site = context.restrictedTraverse('/'.join(site_path) or '/')
+            if ISite.providedBy(site):
+                break
+    except ValueError:
+        # Refs: https://github.com/plone/plone.app.content/issues/103
+        # On error, just return getSite.
+        return getSite()
     return site
 
 


### PR DESCRIPTION
Fix issue with ``get_top_site_from_url``, where in some circumstances a ValueError was thrown.
If that happens, just return ``getSite``.
You will only notice, if you have subsites, access them non-VirtualHost-rooted and an error is thrown.
Then folder contents won't be able to navigate up to the root Plone site.
Fixes #103.