### PR TITLE
Mind the comma

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Add a missing comma between two strings in a list,
+  python merges them into a single string if not.
+  [keul, ekulos, gforcada]
 
 
 3.3.3 (2016-12-02)

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -275,7 +275,7 @@ class ContextInfo(BrowserView):
         'id',
         'is_folderish',
         'last_comment_date',
-        'location'
+        'location',
         'ModificationDate',
         'path',
         'portal_type',


### PR DESCRIPTION
Credits go to @keul and @ekulos that found it yesterday.

If between two strings there are only whitespaces (like between ``'location'`` and ``'ModificationDate'``) python merges them to ``locationModificationDate``.