### PR TITLE
Check for containerish behavior in ``@@allow_upload``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Check for containerish behavior in ``@@allow_upload``.
+  Fixes a case, where ``@allow_upload`` reported ``True`` for content of type ``File``.
+  [thet]
 
 
 3.3.4 (2016-12-30)

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
+from OFS.interfaces import IFolder
 from plone.app.dexterity.interfaces import IDXFileFactory
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.uuid.interfaces import IUUID
@@ -208,9 +209,14 @@ class AllowUploadView(BrowserView):
         context = self.context
         if self.request.form.get('path'):
             context = context.restrictedTraverse(self.request.form.get('path'))
-        allowed_types = [t.getId() for t in context.allowedContentTypes()]
-        allow_images = u'Image' in allowed_types
-        allow_files = u'File' in allowed_types
+
+        allow_images = False
+        allow_files = False
+        if IFolder.providedBy(context):
+            allowed_types = [t.getId() for t in context.allowedContentTypes()]
+            allow_images = u'Image' in allowed_types
+            allow_files = u'File' in allowed_types
+
         return json.dumps({
             'allowUpload': allow_images or allow_files,
             'allowImages': allow_images,

--- a/plone/app/content/tests/test_contents.py
+++ b/plone/app/content/tests/test_contents.py
@@ -97,15 +97,35 @@ class AllowUploadViewTests(unittest.TestCase):
         self.portal.portal_types._setObject('type1', type1_fti)
         self.type1_fti = type1_fti
 
+        # TYPE 2
+        type2_fti = DexterityFTI('type1')
+        type2_fti.klass = 'plone.dexterity.content.Item'
+        type2_fti.filter_content_types = True
+        type2_fti.allowed_content_types = []
+        type2_fti.behaviors = (
+            'plone.app.dexterity.behaviors.metadata.IBasic'
+        )
+        self.portal.portal_types._setObject('type2', type2_fti)
+        self.type2_fti = type2_fti
+
         login(self.portal, TEST_USER_NAME)
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
         self.portal.invokeFactory('type1', id='it1', title='Item 1')
+        self.portal.invokeFactory('type2', id='it2', title='Item 2')
 
     def test_allow_upload(self):
         """Test, if file or images are allowed in a container in different FTI
         configurations.
         """
+
+        # Test non-container, none allowed
+        allow_upload = self.portal.it2.restrictedTraverse('@@allow_upload')
+        allow_upload = json.loads(allow_upload())
+
+        self.assertEqual(allow_upload['allowUpload'], False)
+        self.assertEqual(allow_upload['allowImages'], False)
+        self.assertEqual(allow_upload['allowFiles'], False)
 
         # Test none allowed
         self.type1_fti.allowed_content_types = []


### PR DESCRIPTION
Fixes a case, where ``@allow_upload`` reported ``True`` for content of type ``File``.