### PR TITLE
Fix issue where some folder actions failed when path above had privat levels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix issue where some actions (copy, delete, paste) on contents view did not
+  work if there were any private (innaccessible for the current user) levels the
+  current path
+  [datakurre]
 
 
 3.4 (2017-04-01)

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -88,8 +88,9 @@ class ContentsBaseAction(BrowserView):
         context = aq_inner(self.context)
         selection = self.get_selection()
 
-        self.dest = self.site.restrictedTraverse(
-            str(self.request.form['folder'].lstrip('/')))
+        parts = str(self.request.form['folder'].lstrip('/')).split('/')
+        parent = self.site.unrestrictedTraverse('/'.join(parts[:-1]))
+        self.dest = parent.restrictedTraverse(parts[-1])
 
         self.catalog = getToolByName(context, 'portal_catalog')
         self.mtool = getToolByName(self.context, 'portal_membership')

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -35,8 +35,9 @@ class PasteActionView(ContentsBaseAction):
         self.protect()
         self.errors = []
 
-        self.dest = self.site.restrictedTraverse(
-            str(self.request.form['folder'].lstrip('/')))
+        parts = str(self.request.form['folder'].lstrip('/')).split('/')
+        parent = self.site.unrestrictedTraverse('/'.join(parts[:-1]))
+        self.dest = parent.restrictedTraverse(parts[-1])
 
         try:
             self.dest.manage_pasteObjects(self.request['__cp'])


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.content/issues/123

The new tests will fail with current CMFPlone master for Plone 5.1 until https://github.com/plone/Products.CMFPlone/pull/1996 (similar regression in catalog search)