### PR TITLE
Allow operation on inactive content for all folder content actions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ New features:
 
 Bug fixes:
 
+- Allow operation on inactive content for all folder content actions.
+  This allows deleting, renaming, rearranging and changing workflow of content which expiration date has already been met or which effective date hasn't met yet.
+  [thet]
+
 - Fix issue where some actions (copy, delete, paste) on contents view did not
   work if there were any private (innaccessible for the current user) levels the
   current path

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -95,7 +95,8 @@ class ContentsBaseAction(BrowserView):
         self.catalog = getToolByName(context, 'portal_catalog')
         self.mtool = getToolByName(self.context, 'portal_membership')
 
-        for brain in self.catalog(UID=selection):
+        brains = self.catalog(UID=selection, show_inactive=True)
+        for brain in brains:
             # remove everyone so we know if we missed any
             selection.remove(brain.UID)
             obj = brain.getObject()
@@ -316,7 +317,7 @@ class ContextInfo(BrowserView):
 
         catalog = getToolByName(self.context, 'portal_catalog')
         try:
-            brains = catalog(UID=IUUID(self.context))
+            brains = catalog(UID=IUUID(self.context), show_inactive=True)
         except TypeError:
             brains = []
         item = None

--- a/plone/app/content/browser/contents/delete.py
+++ b/plone/app/content/browser/contents/delete.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 from AccessControl import Unauthorized
 from AccessControl.Permissions import delete_objects
+from plone.app.content.browser.contents import ContentsBaseAction
+from plone.app.content.interfaces import IStructureAction
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.content.browser.contents import ContentsBaseAction
-from plone.app.content.interfaces import IStructureAction
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implementer
+
 import json
 
 
@@ -52,7 +53,7 @@ class DeleteActionView(ContentsBaseAction):
                                            name='delete_confirmation_info')
             selection = self.get_selection()
             catalog = getToolByName(self.context, 'portal_catalog')
-            brains = catalog(UID=selection)
+            brains = catalog(UID=selection, show_inactive=True)
             items = [i.getObject() for i in brains]
             self.request.response.setHeader(
                 'Content-Type', 'application/json; charset=utf-8'

--- a/plone/app/content/browser/contents/rearrange.py
+++ b/plone/app/content/browser/contents/rearrange.py
@@ -82,7 +82,8 @@ class RearrangeActionView(OrderContentsBaseAction):
                     'query': '/'.join(self.context.getPhysicalPath()),
                     'depth': 1
                 },
-                'sort_on': self.request.form.get('rearrange_on')
+                'sort_on': self.request.form.get('rearrange_on'),
+                'show_inactive': True
             }
             brains = catalog(**query)
             if self.request.form.get('reversed') == 'true':

--- a/plone/app/content/browser/contents/rename.py
+++ b/plone/app/content/browser/contents/rename.py
@@ -61,7 +61,7 @@ class RenameActionView(ContentsBaseAction):
                 continue
             index = key.split('_')[-1]
             uid = self.request.form[key]
-            brains = catalog(UID=uid)
+            brains = catalog(UID=uid, show_inactive=True)
             if len(brains) == 0:
                 missing.append(uid)
                 continue

--- a/plone/app/content/browser/contents/workflow.py
+++ b/plone/app/content/browser/contents/workflow.py
@@ -50,7 +50,7 @@ class WorkflowActionView(ContentsBaseAction):
             # asking for render information
             selection = self.get_selection()
             catalog = getToolByName(self.context, 'portal_catalog')
-            brains = catalog(UID=selection)
+            brains = catalog(UID=selection, show_inactive=True)
             transitions = []
             for brain in brains:
                 obj = brain.getObject()


### PR DESCRIPTION
This allows deleting, renaming, rearranging and changing workflow of content which expiration date has already been met or which effective date hasn't met yet.

@datakurre , @jensens & @mauritsvanrees this might be of interest for you.

AFAIK, this shouldn't have anything to do with my PR https://github.com/plone/Products.CMFPlone/pull/1952 and this bug should already been present in Plone 5.0.

I'll deliver tests later, I have to run.