### PR TITLE
Folder Contents: More compact toolbar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,12 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Folder Contents: More compact toolbar
+  Instead of showing titles in the menu bar action buttons, show only icons and add a tooltip.
+  This makes the menu bar more compact and avoids breaking into two lines.
+  Also: Better icons for copy and paste.
+  [thet]
+
 
 Bug fixes:
 

--- a/plone/app/content/browser/contents/copy.py
+++ b/plone/app/content/browser/contents/copy.py
@@ -20,9 +20,9 @@ class CopyAction(object):
 
     def get_options(self):
         return {
-            'title': translate(_('Copy'), context=self.request),
+            'tooltip': translate(_('Copy'), context=self.request),
             'id': 'copy',
-            'icon': 'copy',
+            'icon': 'duplicate',
             'url': self.context.absolute_url() + '/@@fc-copy'
         }
 

--- a/plone/app/content/browser/contents/cut.py
+++ b/plone/app/content/browser/contents/cut.py
@@ -20,7 +20,7 @@ class CutAction(object):
 
     def get_options(self):
         return {
-            'title': translate(_('Cut'), context=self.request),
+            'tooltip': translate(_('Cut'), context=self.request),
             'id': 'cut',
             'icon': 'scissors',
             'url': self.context.absolute_url() + '/@@fc-cut'

--- a/plone/app/content/browser/contents/delete.py
+++ b/plone/app/content/browser/contents/delete.py
@@ -26,7 +26,7 @@ class DeleteAction(object):
 
     def get_options(self):
         return {
-            'title': translate(_('Delete'), context=self.request),
+            'tooltip': translate(_('Delete'), context=self.request),
             'id': 'delete',
             'icon': 'trash',
             'context': 'danger',

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -19,9 +19,9 @@ class PasteAction(object):
 
     def get_options(self):
         return {
-            'title': translate(_('Paste'), context=self.request),
+            'tooltip': translate(_('Paste'), context=self.request),
             'id': 'paste',
-            'icon': 'paste',
+            'icon': 'open-file',
             'url': self.context.absolute_url() + '/@@fc-paste'
         }
 

--- a/plone/app/content/browser/contents/properties.py
+++ b/plone/app/content/browser/contents/properties.py
@@ -28,7 +28,7 @@ class PropertiesAction(object):
     def get_options(self):
         base_vocabulary = '%s/@@getVocabulary?name=' % getSite().absolute_url()
         return {
-            'title': translate(_('Properties'), context=self.request),
+            'tooltip': translate(_('Properties'), context=self.request),
             'id': 'properties',
             'icon': 'edit',
             'url': self.context.absolute_url() + '/@@fc-properties',

--- a/plone/app/content/browser/contents/rename.py
+++ b/plone/app/content/browser/contents/rename.py
@@ -33,7 +33,7 @@ class RenameAction(object):
 
     def get_options(self):
         return {
-            'title': translate(_('Rename'), context=self.request),
+            'tooltip': translate(_('Rename'), context=self.request),
             'id': 'rename',
             'icon': 'random',
             'url': self.context.absolute_url() + '/@@fc-rename',

--- a/plone/app/content/browser/contents/tags.py
+++ b/plone/app/content/browser/contents/tags.py
@@ -21,7 +21,7 @@ class TagsAction(object):
     def get_options(self):
         base_vocabulary = '%s/@@getVocabulary?name=' % getSite().absolute_url()
         return {
-            'title': translate(_('Tags'), context=self.request),
+            'tooltip': translate(_('Tags'), context=self.request),
             'id': 'tags',
             'icon': 'tags',
             'url': self.context.absolute_url() + '/@@fc-tags',

--- a/plone/app/content/browser/contents/workflow.py
+++ b/plone/app/content/browser/contents/workflow.py
@@ -23,7 +23,7 @@ class WorkflowAction(object):
 
     def get_options(self):
         return {
-            'title': translate(_('State'), context=self.request),
+            'tooltip': translate(_('State'), context=self.request),
             'id': 'workflow',
             'icon': 'lock',
             'url': self.context.absolute_url() + '/@@fc-workflow',


### PR DESCRIPTION
Folder Contents: More compact toolbar
Instead of showing titles in the menu bar action buttons, show only icons and add a tooltip.
This makes the menu bar more compact and avoids breaking into two lines.
Also: Better icons for copy and paste.


Merge all these:
https://github.com/plone/plone.app.content/pull/138
https://github.com/plone/mockup/pull/811
https://github.com/plone/Products.CMFPlone/pull/2164