### PR TITLE
Fixed some translations in the delete pop-over

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix translations in the delete pop-over
+  [arsenico13]
 
 
 3.4.4 (2017-08-27)

--- a/plone/app/content/browser/contents/delete.py
+++ b/plone/app/content/browser/contents/delete.py
@@ -32,11 +32,11 @@ class DeleteAction(object):
             'context': 'danger',
             'url': self.context.absolute_url() + '/@@fc-delete',
             'form': {
-                'title': _('Delete selected items'),
-                'submitText': _('Yes'),
+                'title': translate(_('Delete selected items'), context=self.request),
+                'submitText': translate(_('Yes'), context=self.request),
                 'submitContext': 'danger',
                 'template': self.template(),
-                'closeText': _('No'),
+                'closeText': translate(_('No'), context=self.request),
                 'dataUrl': self.context.absolute_url() + '/@@fc-delete'
             }
         }


### PR DESCRIPTION
In the pop-over form when deleting something, there were some "missing" translations (some labels weren't translated when rendered in the template).

Now they get translated before being sent to the template, solving the problem.