### PR TITLE
Allow ``plonejsi18n`` accept empty domains when calling.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Bug fixes:
 
 - Fix translations in the delete pop-over
   [arsenico13]
+- Allow ``plonejsi18n`` accept empty domains when calling.
+  This avoids ``BadRequest`` errors, when being called without a domain url query string.
+  [thet]
 
 
 3.4.4 (2017-08-27)

--- a/plone/app/content/browser/i18n.py
+++ b/plone/app/content/browser/i18n.py
@@ -30,13 +30,15 @@ class i18njs(BrowserView):
             catalog = td._data[mo_path]._catalog
         return catalog._catalog
 
-    def __call__(self, domain, language=None):
-        if domain is None:
-            return
-        if language is None:
-            language = self.request['LANGUAGE']
+    def __call__(self, domain=None, language=None):
 
-        catalog = self._gettext_catalog(domain, language)
+        if domain is None:
+            catalog = {}
+        else:
+            if language is None:
+                language = self.request['LANGUAGE']
+            catalog = self._gettext_catalog(domain, language)
+
         response = self.request.response
         response.setHeader('Content-Type', 'application/json; charset=utf-8')
         response.setBody(json.dumps(catalog))


### PR DESCRIPTION
This avoids ``BadRequest`` errors, when being called without a domain url query string.