### PR TITLE
fix drag & drop in folder listing on plone root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- fix drag & drop in folder listing on plone root
+  [huub_bouma]
 
 
 3.4.5 (2017-11-24)

--- a/plone/app/content/browser/contents/rearrange.py
+++ b/plone/app/content/browser/contents/rearrange.py
@@ -53,7 +53,7 @@ class ItemOrderActionView(OrderContentsBaseAction):
             return self.message()
 
         delta = int(delta)
-        subset_ids = json_loads(self.request.form.get('subset_ids', '[]'))
+        subset_ids = json_loads(self.request.form.get('subsetIds', 'null'))
         if subset_ids:
             position_id = [
                 (ordering.getObjectPosition(i), i) for i in subset_ids
@@ -63,7 +63,7 @@ class ItemOrderActionView(OrderContentsBaseAction):
                 self.errors.append(_('Client/server ordering mismatch'))
                 return self.message()
 
-        ordering.moveObjectsByDelta([id], delta)
+        ordering.moveObjectsByDelta([id], delta, subset_ids)
         return self.message()
 
 

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -369,6 +369,16 @@ class RearrangeDXTest(BaseTest):
             )
             self.bf[newid].reindexObject()
 
+        # create 3 documents in plone root
+        for idx in range(0, 3):
+            _id = "page_{}".format(idx)
+            self.portal.invokeFactory(
+                'Document',
+                id=_id,
+                title="Page {}".format(idx)
+            )
+            self.portal[_id].reindexObject()
+
         self.env = {'HTTP_ACCEPT_LANGUAGE': 'en', 'REQUEST_METHOD': 'POST'}
         self.request = makerequest(self.layer['app']).REQUEST
         self.request.environ.update(self.env)
@@ -467,6 +477,36 @@ class RearrangeDXTest(BaseTest):
                 ('f1', 'Folder 3'),
                 ('f3', 'Folder 1'),
                 ('f4', 'Folder 0'),
+            ]
+        )
+
+    def test_item_order_move_by_delta_in_plone_root(self):
+        from plone.app.content.browser.contents.rearrange import ItemOrderActionView  # noqa
+
+        # first move the 'basefolder' to the top
+        self.request.form.update({
+            'id': 'basefolder',
+            'delta': 'top',
+        })
+        view = ItemOrderActionView(self.portal, self.request)
+        view()
+
+        # move 'basefolder' two positions down
+        self.request.form.update({
+            'id': 'basefolder',
+            'delta': '2',
+            'subsetIds': '["basefolder", "page_0", "page_1", "page_2"]',
+        })
+        view = ItemOrderActionView(self.portal, self.request)
+        view()
+
+        self.assertEqual(
+            [(c[0], c[1].Title()) for c in self.portal.contentItems()],
+            [
+                ('page_0', 'Page 0'),
+                ('page_1', 'Page 1'),
+                ('basefolder', 'Folder Base'),
+                ('page_2', 'Page 2'),
             ]
         )
 


### PR DESCRIPTION
I ran into a bug in plone 5.1 (latest) where the drag & drop of content items in the root plone folder doesn't work. This PR fixes it.

Cheers, Huub