### PR TITLE
Folder contents: When copying items keep the order in which they were selected.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Folder contents: When copying items keep the order in which they were selected.
+  Fixes: https://github.com/plone/Products.CMFPlone/issues/1875
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/content/browser/contents/copy.py
+++ b/plone/app/content/browser/contents/copy.py
@@ -51,4 +51,4 @@ class CopyActionView(ContentsBaseAction):
 
     def __call__(self):
         self.oblist = []
-        return super(CopyActionView, self).__call__()
+        return super(CopyActionView, self).__call__(keep_selection_order=True)


### PR DESCRIPTION
Fixes: https://github.com/plone/Products.CMFPlone/issues/1875

plone.app.content.browser.contents.ContentsBaseView did a catalog call with the selection list, which is a list of UUIDs. The order isn't preserved in that case. 

My fix preserves the order in which they were selected - not necessarily the original sort order of the folder the items are copied from. When doing a "select all" in the folder contents view, the selection is done in the folder's sort order. I think this gives more flexibility to power users.

Note: The reason why I fixed the selection order only for the copy view (``plone.app.content.browser.contents.copy.CopyActionView``) is because there were a lot of tests failing when I tried to apply this for ``plone.app.content.browser.contents.ContentsBaseAction``.
In some cases like deleting, etc. the order in which items are selected might not be practical or possible at all.
  