### PR TITLE
Added support for multiple po file on same i18n domain for plonejsi18n view.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Added support for multiple po file on same i18n domain for plonejsi18n view.
+  [mamico]
 
 
 3.4.5 (2017-11-24)

--- a/plone/app/content/browser/i18n.py
+++ b/plone/app/content/browser/i18n.py
@@ -23,12 +23,14 @@ class i18njs(BrowserView):
                 return
             else:
                 language = baselanguage
-        mo_path = td._catalogs[language][0]
-        catalog = td._data[mo_path]._catalog
-        if catalog is None:
-            td._data[mo_path].reload()
+        _catalog = {}
+        for mo_path in td._catalogs[language]:
             catalog = td._data[mo_path]._catalog
-        return catalog._catalog
+            if catalog is None:
+                td._data[mo_path].reload()
+                catalog = td._data[mo_path]._catalog
+            _catalog.update(catalog._catalog)
+        return _catalog
 
     def __call__(self, domain=None, language=None):
 


### PR DESCRIPTION
plonejsi18n view currently support only the first .po file, but many tmes there is a need to add new translation or override defaults, using other .po files on same i18n domain.

this PR try to fix this.