### PR TITLE
Remove p.a.testing.bbb usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Bug fixes:
 - Added support for multiple po file on same i18n domain for plonejsi18n view.
   [mamico]
 
+- Remove usage of plone.app.testing.bbb code,
+  this removes test isolation problems.
+  [gforcada]
+
 
 3.4.5 (2017-11-24)
 ------------------

--- a/plone/app/content/basecontent.rst
+++ b/plone/app/content/basecontent.rst
@@ -2,6 +2,10 @@
 Basic content
 =============
 
+.. code-block:: python
+
+    >>> portal = layer['portal']
+
 plone.app.content provides some helper base classes for content. Here are
 some simple examples of using them.
 .. code-block:: python
@@ -63,8 +67,8 @@ We can now create the items.
 We need to add it to an object manager for acquisition to do its magic.
 .. code-block:: python
 
-    >>> newid = self.portal._setObject(container.id, container)
-    >>> container = getattr(self.portal, newid)
+    >>> newid = portal._setObject(container.id, container)
+    >>> container = getattr(portal, newid)
 
 We will add the item directly to the container later.
 .. code-block:: python
@@ -124,11 +128,11 @@ ObjectManager one.
 Both pieces of content should have been cataloged.
 .. code-block:: python
 
-    >>> container = self.portal['my-container']
+    >>> container = portal['my-container']
     >>> item = container['my-item']
 
     >>> from Products.CMFCore.utils import getToolByName
-    >>> catalog = getToolByName(self.portal, 'portal_catalog')
+    >>> catalog = getToolByName(portal, 'portal_catalog')
     >>> [b.Title for b in catalog(getId = 'my-container')]
     ['A sample container']
     >>> [b.Title for b in catalog(getId = 'my-item')]

--- a/plone/app/content/testing.py
+++ b/plone/app/content/testing.py
@@ -13,6 +13,8 @@ from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
+import doctest
+
 
 @implementer(IVocabularyFactory)
 class ExampleVocabulary(object):
@@ -140,3 +142,10 @@ PLONE_APP_CONTENT_AT_INTEGRATION_TESTING = IntegrationTesting(
 PLONE_APP_CONTENT_AT_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_APP_CONTENT_AT_FIXTURE, ),
     name="PloneAppContentAT:Functional")
+
+
+optionflags = (
+    doctest.REPORT_ONLY_FIRST_FAILURE
+    | doctest.ELLIPSIS
+    | doctest.NORMALIZE_WHITESPACE
+)

--- a/plone/app/content/tests/base.py
+++ b/plone/app/content/tests/base.py
@@ -1,9 +1,0 @@
-from plone.app.testing.bbb import PloneTestCase
-
-
-class ContentTestCase(PloneTestCase):
-    pass
-
-
-class ContentFunctionalTestCase(PloneTestCase):
-    pass

--- a/plone/app/content/tests/test_basecontent.py
+++ b/plone/app/content/tests/test_basecontent.py
@@ -1,15 +1,28 @@
 # -*- coding: utf-8 -*-
-from Testing import ZopeTestCase as ztc
-from plone.app.content.tests.base import ContentFunctionalTestCase
+from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
+from plone.app.content.testing import optionflags
+from plone.testing import layered
 import doctest
 import unittest
 
 
+doctests = (
+    'basecontent.rst',
+)
+
+
 def test_suite():
-    return unittest.TestSuite((
-        ztc.ZopeDocFileSuite(
-            'basecontent.rst',
-            package='plone.app.content',
-            test_class=ContentFunctionalTestCase,
-            optionflags=(doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)),
-    ))
+    suite = unittest.TestSuite()
+    tests = [
+        layered(
+            doctest.DocFileSuite(
+                test_file,
+                package='plone.app.content',
+                optionflags=optionflags,
+            ),
+            layer=PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING,
+        )
+        for test_file in doctests
+    ]
+    suite.addTests(tests)
+    return suite


### PR DESCRIPTION
The bbb module uses ZopeTestCase, which end ups creating test isolation problems.

See https://github.com/plone/Products.CMFPlone/issues/2290