### PR TITLE
ReindexObject when change state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- fc_workflow view now reindex the object after state change.
+  This fix the problem that some index dates (effective and modified for example) was
+  updated only when the state was changed from the toolbar.
+  [cekk]
 
 3.5.3 (2018-06-18)
 ------------------

--- a/plone/app/content/browser/contents/workflow.py
+++ b/plone/app/content/browser/contents/workflow.py
@@ -83,6 +83,7 @@ class WorkflowActionView(ContentsBaseAction):
                 if recurse and IFolderish.providedBy(obj):
                     for sub in obj.values():
                         self.action(sub)
+                obj.reindexObject()
             except ConflictError:
                 raise
             except Exception:

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from DateTime import DateTime
-from plone import api
 from plone.app.content.testing import PLONE_APP_CONTENT_AT_INTEGRATION_TESTING
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
@@ -168,7 +167,7 @@ class PropertiesArchetypesTest(BaseTest):
 
 class WorkflowTest(BaseTest):
 
-    layer = PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
+    layer = PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 
     def convertDateTimeToIndexRepr(self, date):
         t_tup = date.toZone('UTC').parts()
@@ -189,7 +188,7 @@ class WorkflowTest(BaseTest):
         default_effective_index = self.convertDateTimeToIndexRepr(
             default_effective
         )
-        pc = api.portal.get_tool(name='portal_catalog')
+        pc = getToolByName(self.portal, "portal_catalog")
         # i need to call it, to populate catalog indexes
         pc()
         self.assertEquals(

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from DateTime import DateTime
+from plone import api
 from plone.app.content.testing import PLONE_APP_CONTENT_AT_INTEGRATION_TESTING
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
@@ -14,6 +15,7 @@ from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from six.moves.urllib.parse import urlparse
 from Testing.makerequest import makerequest
+from transaction import commit
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.interface import alsoProvides
 from zope.publisher.browser import TestRequest
@@ -168,15 +170,45 @@ class WorkflowTest(BaseTest):
 
     layer = PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
 
+    def convertDateTimeToIndexRepr(self, date):
+        t_tup = date.toZone('UTC').parts()
+        yr = t_tup[0]
+        mo = t_tup[1]
+        dy = t_tup[2]
+        hr = t_tup[3]
+        mn = t_tup[4]
+
+        return ((((yr * 12 + mo) * 31 + dy) * 24 + hr) * 60 + mn)
+
     def testStateChange(self):
         from plone.app.content.browser.contents.workflow import WorkflowActionView  # noqa
         self.request.form['transition'] = 'publish'
+        default_effective = DateTime('1969/12/31 00:00:00 {0}'.format(
+            DateTime().timezone()
+        ))
+        default_effective_index = self.convertDateTimeToIndexRepr(
+            default_effective
+        )
+        pc = api.portal.get_tool(name='portal_catalog')
+        # i need to call it, to populate catalog indexes
+        pc()
+        self.assertEquals(
+            pc.uniqueValuesFor('effective'),
+            (default_effective_index,))
         view = WorkflowActionView(self.portal.page, self.request)
         view()
         workflowTool = getToolByName(self.portal, "portal_workflow")
         self.assertEquals(
             workflowTool.getInfoFor(self.portal.page, 'review_state'),
             'published')
+        # commit to update indexes in catalog
+        commit()
+        effective_index = self.convertDateTimeToIndexRepr(
+            self.portal.page.effective_date
+        )
+        self.assertEquals(
+            pc.uniqueValuesFor('effective'),
+            (effective_index,))
 
 
 class RenameTest(BaseTest):


### PR DESCRIPTION
Problem: changing state from the toolbar and from the folder_contents view have different results.

The first reindex the catalog, and updates effective and modified date.
The second only set effective_date field attribute to the object, but the indexes are not updated.
For example publishing a document with folder_contents generates inconsistent catalog status:

- modified date: not touched
- effective: metadata is correctly updated, but the index is the default one (1969/01/01)

With this change, we will call a reindexObject() after every state change