### PR TITLE
Added get_objects_from_path_list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Added get_objects_from_path_list to replace skin script. #1801
+  [reinhardt]
 
 Bug fixes:
 

--- a/plone/app/content/browser/content_status_history.py
+++ b/plone/app/content/browser/content_status_history.py
@@ -119,3 +119,12 @@ class ContentStatusHistoryView(BrowserView):
             # Set paths using orgi_paths, otherwise users are getting confused
             orig_paths = self.request.get('orig_paths')
             self.request.set('paths', orig_paths)
+
+    def get_objects_from_path_list(self, paths=[]):
+        contents = []
+        portal = getToolByName(self.context, 'portal_url').getPortalObject()
+        for path in paths:
+            obj = portal.restrictedTraverse(str(path), None)
+            if obj is not None:
+                contents.append(obj)
+        return contents

--- a/plone/app/content/browser/templates/content_status_history.pt
+++ b/plone/app/content/browser/templates/content_status_history.pt
@@ -39,7 +39,7 @@
            tal:define="errors view/errors;
                        review_state context_state/workflow_state;
                        paths python:request.get('paths', ['/'.join(context.getPhysicalPath())]);
-                       batch python:context.getObjectsFromPathList(paths, batch=False);
+                       batch python:view.get_objects_from_path_list(paths);
                        folders_in_publishing python:[o.getId for o in batch if o.isPrincipiaFolderish];
                        came_from python:request.get('HTTP_REFERER', context.absolute_url()).split('?')[0];
                        dummy python:request.set('orig_template', came_from);


### PR DESCRIPTION
Replaces skin script getObjectsFromPathList.py. The option for batching seems to be unused in the skin script so I didn't port it.
See https://github.com/plone/Products.CMFPlone/issues/1801