### PR TITLE
Use get_size instead of getObjSize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-3.5.5 (unreleased)
+3.6.0 (unreleased)
 ------------------
 
 Breaking changes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Use obj.get_size() instead of getObjSize skin script.
+  Allows removing the script and also returns a numerical value.
+  #1801
+  [reinhardt]
 
 Bug fixes:
 

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -180,7 +180,7 @@ class FileUploadView(BrowserView):
             try:
                 result['size'] = obj.getSize()
             except AttributeError:
-                result['size'] = obj.getObjSize()
+                result['size'] = obj.get_size()
 
         if tusrequest:
             tus.cleanup_file()

--- a/plone/app/content/browser/reviewlist.py
+++ b/plone/app/content/browser/reviewlist.py
@@ -5,6 +5,7 @@ from plone.app.content.browser.tableview import TableBrowserView
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from Products.CMFPlone.utils import human_readable_size
 from six.moves import map
 from six.moves.urllib.parse import quote_plus
 from zope.component import getMultiAdapter
@@ -114,7 +115,7 @@ class ReviewListTable(object):
                 title_or_id=obj.pretty_title_or_id(),
                 description=obj.Description(),
                 obj_type=obj.Type,
-                size=obj.getObjSize(),
+                size=human_readable_size(obj.get_size()),
                 modified=modified,
                 type_class=type_class,
                 wf_state=review_state,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '3.5.5.dev0'
+version = '3.6.0.dev0'
 
 setup(
     name='plone.app.content',
@@ -14,7 +14,6 @@ setup(
     ]),
     classifiers=[
         "Framework :: Plone",
-        "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Programming Language :: Python",


### PR DESCRIPTION
Use obj.get_size() instead of getObjSize skin script.
Allows removing the script and also returns a numerical value which is more consistent with what is returned in the other cases.
See also https://github.com/plone/Products.CMFPlone/issues/1801
