### PR TITLE
Fix URLs in folder_contents action buttons.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix URLs in folder_contents action buttons.
+  They need to be relative to the site root (resp. top site from url due to path handling in the structure pattern) and contain a {path} placeholder.
+  Fixes: https://github.com/plone/mockup/issues/857
+  [thet]
 
 
 3.5.4 (2018-09-23)

--- a/plone/app/content/browser/contents/copy.py
+++ b/plone/app/content/browser/contents/copy.py
@@ -5,6 +5,7 @@ from OFS.Moniker import Moniker
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from zope.i18n import translate
 from zope.interface import implementer
 
@@ -19,11 +20,13 @@ class CopyAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         return {
             'tooltip': translate(_('Copy'), context=self.request),
             'id': 'copy',
             'icon': 'duplicate',
-            'url': self.context.absolute_url() + '/@@fc-copy'
+            'url': '%s{path}/@@fc-copy' % base_url,
         }
 
 

--- a/plone/app/content/browser/contents/cut.py
+++ b/plone/app/content/browser/contents/cut.py
@@ -5,6 +5,7 @@ from OFS.Moniker import Moniker
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from zope.i18n import translate
 from zope.interface import implementer
 
@@ -19,11 +20,13 @@ class CutAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         return {
             'tooltip': translate(_('Cut'), context=self.request),
             'id': 'cut',
             'icon': 'scissors',
-            'url': self.context.absolute_url() + '/@@fc-cut'
+            'url': '%s{path}/@@fc-cut' % base_url,
         }
 
 

--- a/plone/app/content/browser/contents/delete.py
+++ b/plone/app/content/browser/contents/delete.py
@@ -5,6 +5,7 @@ from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
@@ -25,19 +26,21 @@ class DeleteAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         return {
             'tooltip': translate(_('Delete'), context=self.request),
             'id': 'delete',
             'icon': 'trash',
             'context': 'danger',
-            'url': self.context.absolute_url() + '/@@fc-delete',
+            'url': '%s{path}/@@fc-delete' % base_url,
             'form': {
                 'title': translate(_('Delete selected items'), context=self.request),
                 'submitText': translate(_('Yes'), context=self.request),
                 'submitContext': 'danger',
                 'template': self.template(),
                 'closeText': translate(_('No'), context=self.request),
-                'dataUrl': self.context.absolute_url() + '/@@fc-delete'
+                'dataUrl': '%s{path}/@@fc-delete' % base_url,
             }
         }
 

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -3,6 +3,7 @@ from AccessControl import Unauthorized
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from ZODB.POSException import ConflictError
 from zope.i18n import translate
 from zope.interface import implementer
@@ -18,11 +19,13 @@ class PasteAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         return {
             'tooltip': translate(_('Paste'), context=self.request),
             'id': 'paste',
             'icon': 'open-file',
-            'url': self.context.absolute_url() + '/@@fc-paste'
+            'url': '%s{path}/@@fc-paste' % base_url,
         }
 
 

--- a/plone/app/content/browser/contents/properties.py
+++ b/plone/app/content/browser/contents/properties.py
@@ -7,6 +7,7 @@ from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFCore.interfaces._content import IFolderish
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getUtility
 from zope.component.hooks import getSite
@@ -26,19 +27,21 @@ class PropertiesAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         base_vocabulary = '%s/@@getVocabulary?name=' % getSite().absolute_url()
         return {
             'tooltip': translate(_('Properties'), context=self.request),
             'id': 'properties',
             'icon': 'edit',
-            'url': self.context.absolute_url() + '/@@fc-properties',
+            'url': '%s{path}/@@fc-properties' % base_url,
             'form': {
                 'title': _('Modify properties on items'),
                 'template': self.template(
                     vocabulary_url='%splone.app.vocabularies.Users' % (
                         base_vocabulary)
                 ),
-                'dataUrl': self.context.absolute_url() + '/@@fc-properties',
+                'dataUrl': '%s{path}/@@fc-properties' % base_url,
             }
         }
 

--- a/plone/app/content/browser/contents/rename.py
+++ b/plone/app/content/browser/contents/rename.py
@@ -6,6 +6,7 @@ from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ZODB.POSException import ConflictError
 from zope.component import getMultiAdapter
@@ -14,7 +15,6 @@ from zope.event import notify
 from zope.i18n import translate
 from zope.interface import implementer
 from zope.lifecycleevent import ObjectModifiedEvent
-
 
 import logging
 import six
@@ -35,11 +35,13 @@ class RenameAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         return {
             'tooltip': translate(_('Rename'), context=self.request),
             'id': 'rename',
             'icon': 'random',
-            'url': self.context.absolute_url() + '/@@fc-rename',
+            'url': '%s{path}/@@fc-rename' % base_url,
             'form': {
                 'template': self.template()
             }

--- a/plone/app/content/browser/contents/tags.py
+++ b/plone/app/content/browser/contents/tags.py
@@ -2,6 +2,7 @@
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component.hooks import getSite
 from zope.i18n import translate
@@ -19,12 +20,14 @@ class TagsAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         base_vocabulary = '%s/@@getVocabulary?name=' % getSite().absolute_url()
         return {
             'tooltip': translate(_('Tags'), context=self.request),
             'id': 'tags',
             'icon': 'tags',
-            'url': self.context.absolute_url() + '/@@fc-tags',
+            'url': '%s{path}/@@fc-tags' % base_url,
             'form': {
                 'template': self.template(
                     vocabulary_url='%splone.app.vocabularies.Keywords' % (

--- a/plone/app/content/browser/contents/workflow.py
+++ b/plone/app/content/browser/contents/workflow.py
@@ -5,6 +5,7 @@ from plone.app.content.interfaces import IStructureAction
 from Products.CMFCore.interfaces._content import IFolderish
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.utils import get_top_site_from_url
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ZODB.POSException import ConflictError
 from zope.i18n import translate
@@ -22,15 +23,17 @@ class WorkflowAction(object):
         self.request = request
 
     def get_options(self):
+        site = get_top_site_from_url(self.context, self.request)
+        base_url = site.absolute_url()
         return {
             'tooltip': translate(_('State'), context=self.request),
             'id': 'workflow',
             'icon': 'lock',
-            'url': self.context.absolute_url() + '/@@fc-workflow',
+            'url': '%s{path}/@@fc-workflow' % base_url,
             'form': {
                 'title': _('Change workflow of selected items'),
                 'template': self.template(),
-                'dataUrl': self.context.absolute_url() + '/@@fc-workflow'
+                'dataUrl': '%s{path}/@@fc-workflow' % base_url,
             }
         }
 


### PR DESCRIPTION
They need to be relative to the site root (resp. top site from url due to path handling in the structure pattern) and contain a {path} placeholder.
Fixes: https://github.com/plone/mockup/issues/857

**Targets Plone 5.1, p.a.content 3.5.x branch**

Merge together:
https://github.com/plone/mockup/pull/876
https://github.com/plone/plone.app.content/pull/167
https://github.com/plone/Products.CMFPlone/pull/2577