### PR TITLE
Fix actions using Zope manage_ methods by not passing a request.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,8 +22,11 @@ Bug fixes:
   updated only when the state was changed from the toolbar.
   [cekk]
 
-- Fix various issues in with py3.
+- Fix various issues in py3.
   [pbauer]
+
+- Fix cut, copy, and delete actions in Zope 4.
+  [davisagli]
 
 3.5.3 (2018-06-18)
 ------------------

--- a/plone/app/content/browser/actions.py
+++ b/plone/app/content/browser/actions.py
@@ -234,6 +234,7 @@ class ObjectCutView(LockingBase):
                                         mapping={'title': self.title}))
         self.request.response.setCookie(
             '__cp', cp, path=self.request['BASEPATH1'] or '/')
+        self.request['__cp'] = cp
 
         return self.do_redirect(
             self.view_url,
@@ -262,6 +263,7 @@ class ObjectCopyView(ObjectCutView):
                                         mapping={'title': self.title}))
         self.request.response.setCookie(
             '__cp', cp, path=self.request['BASEPATH1'] or '/')
+        self.request['__cp'] = cp
 
         return self.do_redirect(self.view_url,
                                 _(u'${title} copied.',

--- a/plone/app/content/browser/actions.py
+++ b/plone/app/content/browser/actions.py
@@ -77,7 +77,7 @@ class DeleteConfirmationForm(form.Form, LockingBase):
         # has the context object been acquired from a place it should not have
         # been?
         if self.context.aq_chain == self.context.aq_inner.aq_chain:
-            parent.manage_delObjects(self.context.getId(), self.request)
+            parent.manage_delObjects(self.context.getId())
             IStatusMessage(self.request).add(
                 _(u'${title} has been deleted.', mapping={u'title': title}))
         else:
@@ -227,11 +227,13 @@ class ObjectCutView(LockingBase):
                                         mapping={'title': self.title, }))
 
         try:
-            self.parent.manage_cutObjects(self.context.getId(), self.request)
+            cp = self.parent.manage_cutObjects(self.context.getId())
         except CopyError:
             return self.do_redirect(self.view_url,
                                     _(u'${title} is not moveable.',
                                         mapping={'title': self.title}))
+        self.request.response.setCookie(
+            '__cp', cp, path=self.request['BASEPATH1'] or '/')
 
         return self.do_redirect(
             self.view_url,
@@ -253,11 +255,13 @@ class ObjectCopyView(ObjectCutView):
 
     def do_action(self):
         try:
-            self.parent.manage_copyObjects(self.context.getId(), self.request)
+            cp = self.parent.manage_copyObjects(self.context.getId())
         except CopyError:
             return self.do_redirect(self.view_url,
                                     _(u'${title} is not copyable.',
                                         mapping={'title': self.title}))
+        self.request.response.setCookie(
+            '__cp', cp, path=self.request['BASEPATH1'] or '/')
 
         return self.do_redirect(self.view_url,
                                 _(u'${title} copied.',

--- a/plone/app/content/browser/contents/delete.py
+++ b/plone/app/content/browser/contents/delete.py
@@ -79,7 +79,7 @@ class DeleteActionView(ContentsBaseAction):
             return
         else:
             try:
-                parent.manage_delObjects(obj.getId(), self.request)
+                parent.manage_delObjects(obj.getId())
             except Unauthorized:
                 self.errors.append(
                     _(u'You are not authorized to delete ${title}.',


### PR DESCRIPTION
The presence of a request causes them to try to render a ZMI page,
which is unnecessary and now breaks due to a permission check.