### PR TITLE
Follow default_page_types setting when showing the items that can be selected as default page (Plone 5.1)

### DIFF
--- a/news/182.bugfix
+++ b/news/182.bugfix
@@ -1,0 +1,1 @@
+Follow default_page_types setting when showing the items that can be selected as default page [erral]

--- a/plone/app/content/browser/selection.py
+++ b/plone/app/content/browser/selection.py
@@ -125,5 +125,5 @@ class DefaultPageSelectionView(BrowserView):
                     # Disallow folderish types if you can't add any content.
                     # To override you have to add type to default_page_types
                     continue
-            results.append(brain)
+                results.append(brain)
         return results

--- a/plone/app/content/tests/test_selectdefaultpage.py
+++ b/plone/app/content/tests/test_selectdefaultpage.py
@@ -18,6 +18,10 @@ DOCUMENT = {'id': 'testdoc',
             'title': 'Test Document',
             'description': 'Test Document Description'}
 
+NEWSITEM = {'id': 'testnews',
+            'title': 'Test News Item',
+            'description': 'Test News Item Description'}
+
 
 class SelectDefaultPageDXTestCase(unittest.TestCase):
 
@@ -54,6 +58,16 @@ class SelectDefaultPageDXTestCase(unittest.TestCase):
         doc = getattr(context, DOCUMENT['id'])
         doc.setTitle(DOCUMENT['title'])
         doc.setDescription(DOCUMENT['description'])
+        doc.reindexObject()
+        # we don't want it in the navigation
+        # doc.setExcludeFromNav(True)
+        return doc
+
+    def _createNewsItem(self, context):
+        context.invokeFactory(id=NEWSITEM['id'], type_name='News Item')
+        doc = getattr(context, NEWSITEM['id'])
+        doc.setTitle(NEWSITEM['title'])
+        doc.setDescription(NEWSITEM['description'])
         doc.reindexObject()
         # we don't want it in the navigation
         # doc.setExcludeFromNav(True)
@@ -110,6 +124,15 @@ class SelectDefaultPageDXTestCase(unittest.TestCase):
 
         self.assertEqual(self.browser.url, folder.absolute_url())
         self.assertEqual(folder.getDefaultPage(), 'testdoc')
+
+    def test_selectable_types_filter(self):
+        self.portal.portal_registry['plone.default_page_types'] = [u'News Item']
+        folder = self.portal.testfolder
+        self._createNewsItem(folder)
+
+        view = folder.restrictedTraverse('@@select_default_page')()
+        self.assertTrue('id="testdoc"' not in view)
+        self.assertTrue('id="testnews"' in view)
 
 
 if HAS_AT:


### PR DESCRIPTION
Fixes #182 in 3.5.x branch (Plone 5.1)

Merge together: https://github.com/plone/Products.CMFPlone/pull/2954