### PR TITLE
form description duplicated

### DIFF
--- a/news/186.bugfix
+++ b/news/186.bugfix
@@ -1,0 +1,2 @@
+Description duplicated in object_rename form
+[mamico]

--- a/plone/app/content/browser/templates/object_rename.pt
+++ b/plone/app/content/browser/templates/object_rename.pt
@@ -17,12 +17,6 @@
                 <h1 class="documentFirstHeading"
                     tal:content="view/label">Rename item</h1>
 
-                <div class="documentDescription"
-                     tal:content="view/description">
-                    Each item has a Short Name and a Title, which you can change
-                    by entering the new details below.
-                </div>
-
                 <div id="content-core">
                     <form metal:use-macro="context/@@ploneform-macros/titlelessform" />
                 </div>


### PR DESCRIPTION
the form description is already present in p.a.z3cform titlelessform macro https://github.com/plone/plone.app.z3cform/blob/966b3e6a626c71c7270519540044d0831db7a819/plone/app/z3cform/templates/macros.pt#L43