### PR TITLE
folder_contents filter should not use SearchableText, but Title

### DIFF
--- a/news/189.feature
+++ b/news/189.feature
@@ -1,0 +1,3 @@
+Switch the default index used for filtering in folder_contents from 
+SearchableText to Title
+[frapell]

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -311,6 +311,7 @@ class FolderContentsView(BrowserView):
             'indexOptionsUrl': '%s/@@qsOptions' % base_url,
             'contextInfoUrl': '%s{path}/@@fc-contextInfo' % base_url,
             'setDefaultPageUrl': '%s{path}/@@fc-setDefaultPage' % base_url,
+            'searchParam': 'Title',
             'availableColumns': columns,
             'attributes': ['Title', 'path', 'getURL', 'getIcon', 'getMimeIcon', 'portal_type'] + list(columns.keys()),  # noqa
             'buttons': self.get_actions(),


### PR DESCRIPTION
This is how it works today:

![Screenshot_20191211_151300](https://user-images.githubusercontent.com/851006/70648889-cbb40c00-1c2a-11ea-90bc-ff82ac39cdc9.png)

This is how it will work, if this PR is merged

![Screenshot_20191211_151755](https://user-images.githubusercontent.com/851006/70648908-d8d0fb00-1c2a-11ea-9db8-c102f2f8ecc1.png)

![Screenshot_20191211_151824](https://user-images.githubusercontent.com/851006/70648916-db335500-1c2a-11ea-8be2-66172a4702a7.png)
