### PR TITLE
Fix unicode error.

### DIFF
--- a/news/191.bugfix
+++ b/news/191.bugfix
@@ -1,0 +1,1 @@
+Fix error when having non-ASCII characters in workflow state titles. [busykoala]

--- a/plone/app/content/browser/contents/workflow.py
+++ b/plone/app/content/browser/contents/workflow.py
@@ -2,6 +2,7 @@
 from DateTime import DateTime
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
+from plone.dexterity.utils import safe_unicode
 from Products.CMFCore.interfaces._content import IFolderish
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
@@ -57,7 +58,8 @@ class WorkflowActionView(ContentsBaseAction):
                 for transition in self.pworkflow.getTransitionsFor(obj):
                     tdata = {
                         'id': transition['id'],
-                        'title': self.context.translate(transition['name'])
+                        'title': self.context.translate(
+                            safe_unicode(transition['name']))
                     }
                     if tdata not in transitions:
                         transitions.append(tdata)

--- a/plone/app/content/testing.py
+++ b/plone/app/content/testing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -107,6 +108,20 @@ class PloneAppContent(PloneSandboxLayer):
         portal.portal_workflow.setDefaultChain("simple_publication_workflow")
 
 
+class NonAsciiLayer(PloneSandboxLayer):
+
+    def setUpZope(self, app, configurationContext):
+        import plone.app.content.tests
+
+        xmlconfig.file('profiles/non-ascii-workflow.zcml',
+                       plone.app.content.tests,
+                       context=configurationContext)
+
+    def setUpPloneSite(self, portal):
+        # applyProfile which has non-ascii characters in state titles
+        applyProfile(portal, 'plone.app.content.tests:non-ascii-workflow')
+
+
 if HAS_AT:
     class PloneAppContentAT(PloneAppContent):
 
@@ -139,6 +154,13 @@ PLONE_APP_CONTENT_DX_INTEGRATION_TESTING = IntegrationTesting(
 PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_APP_CONTENTTYPES_FIXTURE, ),
     name="PloneAppContentDX:Functional")
+
+
+# Test layer with a workflow containing non-ascii characters in state titles.
+PLONE_APP_CONTENT_NON_ASCII_LAYER = NonAsciiLayer()
+PLONE_APP_CONTENT_NON_ASCII_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(PLONE_APP_CONTENT_NON_ASCII_LAYER, ),
+    name="PloneAppContentNonAscii:Integration")
 
 
 if HAS_AT:

--- a/plone/app/content/tests/profiles/non-ascii-workflow-profile/workflows.xml
+++ b/plone/app/content/tests/profiles/non-ascii-workflow-profile/workflows.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+    <object name="non-ascii-workflow" meta_type="Workflow" />
+
+</object>

--- a/plone/app/content/tests/profiles/non-ascii-workflow-profile/workflows/non-ascii-workflow/definition.xml
+++ b/plone/app/content/tests/profiles/non-ascii-workflow-profile/workflows/non-ascii-workflow/definition.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             i18n:domain="plone.app.content.tests"
+             workflow_id="non-ascii-workflow"
+             title="Workflow for non-ascii characters"
+             description=""
+             state_variable="review_state"
+             initial_state="initial"
+             i18n:attributes="title">
+
+ <permission>View</permission>
+
+ <state state_id="initial" title="Ïnitial" i18n:attributes="title">
+  <exit-transition transition_id="to_after"/>
+  <permission-map name="View permission for testing non-ascii title"
+                  acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+ </state>
+
+ <state state_id="after" title="Äfter" i18n:attributes="title">
+  <exit-transition transition_id="to_initial"/>
+  <permission-map name="View permission for testing non-ascii title"
+                  acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+ </state>
+
+ <transition transition_id="to_after" new_state="after"
+             title="To Äfter!"
+             trigger="USER"
+             before_script="" after_script=""
+             i18n:attributes="title">
+  <action url="%(content_url)s/content_status_modify?workflow_action=to_after"
+          category="workflow"
+          i18n:translate="">To Äfter!</action>
+  <guard>
+   <guard-permission>Modify portal content</guard-permission>
+  </guard>
+ </transition>
+
+ <transition transition_id="to_initial" new_state="initial"
+             title="To Ïnitial!"
+             trigger="USER"
+             before_script="" after_script=""
+             i18n:attributes="title">
+  <action url="%(content_url)s/content_status_modify?workflow_action=to_initial"
+          category="workflow"
+          i18n:translate="">To Ïnitial!</action>
+  <guard>
+   <guard-permission>Modify portal content</guard-permission>
+  </guard>
+ </transition>
+
+</dc-workflow>

--- a/plone/app/content/tests/profiles/non-ascii-workflow.zcml
+++ b/plone/app/content/tests/profiles/non-ascii-workflow.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="plone.app.content.tests">
+
+    <genericsetup:registerProfile
+        name="non-ascii-workflow"
+        title="plone.app.content.tests: non-ascii-workflow"
+        directory="non-ascii-workflow-profile"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>
+

--- a/plone/app/content/tests/test_non_ascii_characters_in_workflow_state.py
+++ b/plone/app/content/tests/test_non_ascii_characters_in_workflow_state.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from plone.app.content.testing import PLONE_APP_CONTENT_NON_ASCII_INTEGRATION_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from Products.CMFCore.utils import getToolByName
+from plone.uuid.interfaces import IUUID
+
+import unittest
+import json
+
+
+class TestNonAsciiCharactersWorkflow(unittest.TestCase):
+
+    layer = PLONE_APP_CONTENT_NON_ASCII_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        login(self.portal, TEST_USER_NAME)
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        # set non-ascii-workflow for Documents
+        wf_tool = getToolByName(self, 'portal_workflow')
+        wf_tool.setChainForPortalTypes(['Document'], 'non-ascii-workflow')
+
+        # create an object having the non-ascii-workflow assigned
+        self.portal.invokeFactory("Document", "doc")
+
+    def test_non_ascii_characters_in_workflow_title(self):
+        wf_tool = getToolByName(self, 'portal_workflow')
+        workflow_matching_id = list(filter(
+                lambda workflow: ('non-ascii-workflow' in workflow.id),
+                wf_tool.getWorkflowsFor(self.portal.doc)))
+
+        # Make sure that the non-ascii-workflow was assigned to the Document
+        self.assertTrue(workflow_matching_id)
+
+        # Build POST request to get state title for the Document
+        documents_uid = IUUID(self.portal.doc)
+        self.request.form['selection'] = json.dumps(documents_uid)
+        self.request.form['transitions'] = True
+        self.request.form['render'] = 'yes'
+
+        try:
+            # try to do the json request which among other things returns
+            # the workflow state title containing non-ascii characters.
+            self.portal.unrestrictedTraverse('@@fc-workflow')()
+        except UnicodeDecodeError:
+            self.fail('Calling @@fc-workflow raised UnicodeDecodeError \
+                       unexpectedly.')


### PR DESCRIPTION
Close https://github.com/plone/plone.app.content/issues/179

TODO:
- [x] actual fix in code
- [x] add test
- [x] add changelog

Instead of doing this fix in `ftw.lawgiver` (https://github.com/4teamwork/ftw.lawgiver/pull/97) we instead should fix the issue at its source.

The change allows the use of non-ASCII characters in workflow state titles. In many languages apart from English, this could be a requirement.  
Since users can see the workflow state title when doing transitions it should definitely be possible to use non-ASCII as well.