### PR TITLE
Integrate Plone20200121 hotfix: prevent XSS in title. [master]

### DIFF
--- a/news/3021.bugfix
+++ b/news/3021.bugfix
@@ -1,0 +1,3 @@
+Integrate Plone20200121 hotfix: prevent XSS in title.
+Part of https://plone.org/security/hotfix/20200121/xss-in-the-title-field-on-plone-5-0-and-higher
+[maurits]

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -26,6 +26,11 @@ from zope.interface import implementer
 import six
 import zope.deferredimport
 
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
+
 
 zope.deferredimport.deprecated(
     # remove in Plone 5.1
@@ -383,7 +388,7 @@ class ContextInfo(BrowserView):
         while not context == top_site:
             crumbs.append({
                 'id': context.getId(),
-                'title': utils.pretty_title_or_id(context, context)
+                'title': escape(utils.pretty_title_or_id(context, context))
             })
             context = utils.parent(context)
 
@@ -407,6 +412,8 @@ class ContextInfo(BrowserView):
                     val = val()
                 if key == 'path':
                     val = val[len(base_path):]
+                if key == 'Title':
+                    val = escape(val)
                 item[key] = val
 
         self.request.response.setHeader(


### PR DESCRIPTION
Part of https://plone.org/security/hotfix/20200121/xss-in-the-title-field-on-plone-5-0-and-higher