### PR TITLE
Fix cut/copy & paste of many items

### DIFF
--- a/news/200.bugifx
+++ b/news/200.bugifx
@@ -1,0 +1,2 @@
+Save cut/copy clipboard to ``request.SESSION`` instead of a cookie.
+[petschki]

--- a/plone/app/content/browser/contents/copy.py
+++ b/plone/app/content/browser/contents/copy.py
@@ -45,9 +45,9 @@ class CopyActionView(ContentsBaseAction):
             oblist.append(m.dump())
         cp = (0, oblist)
         cp = _cb_encode(cp)
-        resp = self.request.response
-        resp.setCookie('__cp', cp, path='%s' % cookie_path(self.request))
-        self.request['__cp'] = cp
+        self.request.SESSION.set('__cp', cp)
+        # set cookie only for pat-structure actions
+        self.request.response.setCookie('__cp', '1', path='%s' % cookie_path(self.request))  # noqa: E501
 
     def __call__(self):
         self.oblist = []

--- a/plone/app/content/browser/contents/cut.py
+++ b/plone/app/content/browser/contents/cut.py
@@ -49,9 +49,9 @@ class CutActionView(ContentsBaseAction):
             oblist.append(m.dump())
         cp = (1, oblist)
         cp = _cb_encode(cp)
-        resp = self.request.response
-        resp.setCookie('__cp', cp, path='%s' % cookie_path(self.request))
-        self.request['__cp'] = cp
+        self.request.SESSION.set('__cp', cp)
+        # set cookie only for pat-structure to enable paste action
+        self.request.response.setCookie('__cp', '1', path='%s' % cookie_path(self.request))  # noqa: E501
 
     def __call__(self):
         self.oblist = []

--- a/plone/app/content/browser/contents/paste.py
+++ b/plone/app/content/browser/contents/paste.py
@@ -40,7 +40,7 @@ class PasteActionView(ContentsBaseAction):
         self.dest = parent.restrictedTraverse(parts[-1])
 
         try:
-            self.dest.manage_pasteObjects(self.request['__cp'])
+            self.dest.manage_pasteObjects(self.request.SESSION.get('__cp'))
         except ConflictError:
             raise
         except Unauthorized:
@@ -59,4 +59,5 @@ class PasteActionView(ContentsBaseAction):
             else:
                 raise e
 
+        self.request.SESSION.set('__cp', None)
         return self.message()


### PR DESCRIPTION
Save the cut/copy clipboard to `request.SESSION` because browser cookie length is restricted to 4096 bytes.

fixes #200 