### PR TITLE
consume the metadatafields vocabulary for translated columns

### DIFF
--- a/news/203.bugfix
+++ b/news/203.bugfix
@@ -1,0 +1,3 @@
+Use new MetadataFields vocabulary from plone.app.vocabularies to get the translated columns in folder contents.
+The mime_type column is now properly internationalized as "MIME Type".
+[vincentfretin]

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -22,6 +22,7 @@ from zope.component import getUtilitiesFor
 from zope.component import getUtility
 from zope.i18n import translate
 from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
 
 import six
 import zope.deferredimport
@@ -200,38 +201,12 @@ class FolderContentsView(BrowserView):
         return ignored
 
     def get_columns(self):
-        # Base set of columns
-        columns = {
-            'CreationDate': translate(_('Created on'), context=self.request),
-            'Creator': translate(_('Creator'), context=self.request),
-            'Description': translate(_('Description'), context=self.request),
-            'EffectiveDate': translate(_('Publication date'), context=self.request),  # noqa
-            'end': translate(_('End Date'), context=self.request),
-            'exclude_from_nav': translate(_('Excluded from navigation'), context=self.request),  # noqa
-            'ExpirationDate': translate(_('Expiration date'), context=self.request),  # noqa
-            'getObjSize': translate(_('Object Size'), context=self.request),
-            'id': translate(_('ID'), context=self.request),
-            'is_folderish': translate(_('Folder'), context=self.request),
-            'last_comment_date': translate(_('Last comment date'), context=self.request),  # noqa
-            'location': translate(_('Location'), context=self.request),
-            'ModificationDate': translate(_('Last modified'), context=self.request),  # noqa
-            'review_state': translate(_('Review state'), context=self.request),  # noqa
-            'start': translate(_('Start Date'), context=self.request),
-            'Subject': translate(_('Tags'), context=self.request),
-            'Type': translate(_('Type'), context=self.request),
-            'total_comments': translate(_('Total comments'), context=self.request),  # noqa
-        }
-        # Filter out ignored
-        columns = {
-            k: v for k, v in six.iteritems(columns)
-            if k not in self.ignored_columns
-        }
-        # Add in extra metadata columns
-        catalog = getToolByName(self.context, 'portal_catalog')
-        metadata_columns = [column for column in catalog.schema()]
-        for column in metadata_columns:
-            if column not in columns and column not in self.ignored_columns:
-                columns[column] = translate(_(column), context=self.request)
+        columns = {}
+        voc = getUtility(IVocabularyFactory, 'plone.app.vocabularies.MetadataFields')(self.context)
+        for term in voc:
+            if term.value not in self.ignored_columns:
+                columns[term.value] = translate(term.title, context=self.request)
+
         return columns
 
     def get_thumb_scale(self):

--- a/plone/app/content/configure.zcml
+++ b/plone/app/content/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:plone="http://namespaces.plone.org/plone">
 
+    <include package="plone.app.vocabularies" />
     <include package=".browser" />
 
     <!-- Register a name chooser that chooses plone-like normalized names -->

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Products.CMFCore>=2.2.0dev',
         'Products.CMFDynamicViewFTI',  # required for cmf.ModifyViewTemplate
         'Products.CMFPlone',
+        'plone.app.vocabularies>4.1.2',
         'setuptools',
         'simplejson',
         'six',


### PR DESCRIPTION
Related to https://github.com/plone/plone.app.contenttypes/pull/559 to avoid code duplication.
I added plone.app.contenttypes to install_requires, this was already a dependency for the tests.

This PR needs to be tested and merged after https://github.com/plone/plone.app.contenttypes/pull/559