### PR TITLE
Expose pickadate pattern options in property editing template

### DIFF
--- a/news/206.bugfix
+++ b/news/206.bugfix
@@ -1,0 +1,2 @@
+Expose pickadate configuration in folder_contents properties dialog to properly localize the date. This fixes https://github.com/plone/Products.CMFPlone/issues/850
+[erral]

--- a/plone/app/content/browser/contents/properties.py
+++ b/plone/app/content/browser/contents/properties.py
@@ -3,6 +3,7 @@ from DateTime import DateTime
 from plone.app.content.browser.contents import ContentsBaseAction
 from plone.app.content.interfaces import IStructureAction
 from plone.app.dexterity.behaviors.metadata import ICategorization
+from plone.app.widgets.utils import get_datetime_options
 from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFCore.interfaces._content import IFolderish
 from Products.CMFCore.utils import getToolByName
@@ -13,6 +14,8 @@ from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
+
+import json
 
 
 @implementer(IStructureAction)
@@ -36,12 +39,12 @@ class PropertiesAction(object):
                 'title': translate(_('Modify properties on items'), context=self.request),
                 'template': self.template(
                     vocabulary_url='%splone.app.vocabularies.Users' % (
-                        base_vocabulary)
+                        base_vocabulary),
+                    pattern_options=json.dumps(get_datetime_options(self.request))
                 ),
                 'dataUrl': self.context.absolute_url() + '/@@fc-properties',
             }
         }
-
 
 class PropertiesActionView(ContentsBaseAction):
     success_msg = _(u'Successfully updated metadata')

--- a/plone/app/content/browser/contents/templates/properties.pt
+++ b/plone/app/content/browser/contents/templates/properties.pt
@@ -2,12 +2,12 @@
 
   <div class="form-group">
     <label i18n:translate="publiciation_date">Publication Date</label>
-    <input class="form-control pat-pickadate" name="effectiveDate" />
+    <input class="form-control pat-pickadate" name="effectiveDate" tal:attributes="data-pat-pickadate options/pattern_options"/>
   </div>
 
   <div class="form-group">
     <label i18n:translate="expiration_date">Expiration Date</label>
-    <input class="form-control pat-pickadate" name="expirationDate" />
+    <input class="form-control pat-pickadate" name="expirationDate" tal:attributes="data-pat-pickadate options/pattern_options"/>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
This way the popover shown in folder_contents view renders the pickadate widget with the proper language settings.