### PR TITLE
Avoid a deprecation warning

### DIFF
--- a/news/210.misc
+++ b/news/210.misc
@@ -1,0 +1,1 @@
+Resolve deprecation warning [gfrorcada]

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -7,7 +7,6 @@ from plone.app.content.utils import json_loads
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.layout.navigation.root import getNavigationRoot
 from plone.app.querystring import queryparser
-from plone.app.widgets.interfaces import IFieldPermissionChecker
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 from plone.supermodel.utils import mergedTaggedValueDict
 from Products.CMFCore.utils import getToolByName
@@ -31,6 +30,12 @@ import inspect
 import itertools
 import six
 
+# BBB the p.a.widgets import is the deprecated one, 
+# if the newer location is not found, try the old one
+try:
+    from plone.app.z3cform.interfaces import IFieldPermissionChecker
+except ImportError:
+    from plone.app.widgets.interfaces import IFieldPermissionChecker
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
The first release of p.a.z3cform with this import is 3.1.0 released on May 2nd 2019, only Plone 5.2.x series includes that version or newer.