### PR TITLE
Fixed deprecation warning for IFieldPermissionChecker.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for ``IFieldPermissionChecker``.
+[maurits]

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -7,7 +7,7 @@ from plone.app.content.utils import json_loads
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.layout.navigation.root import getNavigationRoot
 from plone.app.querystring import queryparser
-from plone.app.widgets.interfaces import IFieldPermissionChecker
+from plone.app.z3cform.interfaces import IFieldPermissionChecker
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
 from plone.supermodel.utils import mergedTaggedValueDict
 from Products.CMFCore.utils import getToolByName

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -12,7 +12,7 @@ from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from plone.app.widgets.interfaces import IFieldPermissionChecker
+from plone.app.z3cform.interfaces import IFieldPermissionChecker
 from six.moves import range
 from zope.component import getMultiAdapter
 from zope.component import provideAdapter


### PR DESCRIPTION
```
DeprecationWarning: IFieldPermissionChecker is deprecated.
Import IFieldPermissionChecker from plone.app.z3cform.interfaces instead
```