### PR TITLE
Remove compatibility code for Archetypes and older Pythons and Plones

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,7 +90,7 @@ Bug fixes:
 New features:
 
 
-- Switch the default index used for filtering in folder_contents from 
+- Switch the default index used for filtering in folder_contents from
   SearchableText to Title
   [frapell] (#189)
 

--- a/news/215.breaking
+++ b/news/215.breaking
@@ -1,0 +1,3 @@
+Remove compatibility code for Archetypes and older Python and Plone versions.
+This version is only for Plone 6.0.
+[maurits]

--- a/plone/app/content/basecontent.rst
+++ b/plone/app/content/basecontent.rst
@@ -112,11 +112,7 @@ ObjectManager one.
     >>> 'my-item' in container.objectIds()
     True
     >>> del container['my-item']
-    >>> try:
-    ...     from Products.CMFCore.indexing import processQueue
-    ... except ImportError:
-    ...     def processQueue():
-    ...         pass
+    >>> from Products.CMFCore.indexing import processQueue
     >>> _ = processQueue()
     >>> 'my-item' in container
     False

--- a/plone/app/content/browser/actions.py
+++ b/plone/app/content/browser/actions.py
@@ -22,7 +22,6 @@ from zope.event import notify
 from zope.interface import Interface
 from zope.lifecycleevent import ObjectModifiedEvent
 
-import six
 import transaction
 
 
@@ -190,8 +189,6 @@ class ObjectCutView(LockingBase):
 
     @property
     def title(self):
-        if six.PY2:
-            return self.context.Title().decode('utf8')
         return self.context.Title()
 
     @property

--- a/plone/app/content/browser/constraintypes.py
+++ b/plone/app/content/browser/constraintypes.py
@@ -28,7 +28,9 @@ DISABLED = 0
 ENABLED = 1
 
 
-ST = lambda key, title: SimpleTerm(value=key, title=title)
+def ST(key, title):
+    return SimpleTerm(value=key, title=title)
+
 
 # reuse the translations that we had in atcontenttypes
 AMF = MessageFactory('atcontenttypes')

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -25,10 +25,7 @@ from zope.schema.interfaces import IVocabularyFactory
 
 import zope.deferredimport
 
-try:
-    from html import escape
-except ImportError:
-    from cgi import escape
+from html import escape
 
 
 zope.deferredimport.deprecated(

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -23,27 +23,7 @@ from zope.i18n import translate
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 
-import zope.deferredimport
-
 from html import escape
-
-
-zope.deferredimport.deprecated(
-    # remove in Plone 5.1
-    'Import from plone.app.content.browser.content.defaultpage instead',
-    DefaultPage='plone.app.content.browser.content.defaultpage:SetDefaultPageActionView',  # noqa
-)
-zope.deferredimport.deprecated(
-    # remove in Plone 5.1
-    'Import from plone.app.content.browser.content.rearrange instead',
-    ItemOrder='plone.app.content.browser.content.rearrange:ItemOrderActionView',  # noqa
-    Rearrange='plone.app.content.browser.content.rearrange:RearrangeOrderActionView',  # noqa
-)
-
-zope.deferredimport.deprecated(
-    "Import from Products.CMFPlone.utils instead",
-    get_top_site_from_url='Products.CMFPlone:utils.get_top_site_from_url',
-)
 
 
 class ContentsBaseAction(BrowserView):

--- a/plone/app/content/browser/contents/__init__.py
+++ b/plone/app/content/browser/contents/__init__.py
@@ -23,7 +23,6 @@ from zope.i18n import translate
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 
-import six
 import zope.deferredimport
 
 try:

--- a/plone/app/content/browser/contents/rename.py
+++ b/plone/app/content/browser/contents/rename.py
@@ -16,7 +16,6 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 
 import logging
-import six
 import transaction
 
 
@@ -77,8 +76,6 @@ class RenameActionView(ContentsBaseAction):
             sp = transaction.savepoint(optimistic=True)
 
             newid = self.request.form['newid_' + index]
-            if six.PY2:
-                newid = newid.encode('utf8')
             newtitle = self.request.form['newtitle_' + index]
             try:
                 obid = obj.getId()
@@ -106,8 +103,6 @@ class RenameActionView(ContentsBaseAction):
                 raise
             except Exception as e:
                 sp.rollback()
-                if six.PY2:
-                    title = title.decode('utf8')
                 logger.error('Error renaming "{title}": "{exception}"'
                     .format(title=title, exception=e))
                 self.errors.append(_('Error renaming ${title}', mapping={

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -25,7 +25,7 @@ def _bool(val):
 def _tus_int(val):
     try:
         return int(val)
-    except:
+    except (ValueError, TypeError, AttributeError):
         return 60 * 60  # default here...
 
 

--- a/plone/app/content/browser/file.py
+++ b/plone/app/content/browser/file.py
@@ -1,7 +1,6 @@
 from AccessControl import getSecurityManager
 from OFS.interfaces import IFolder
 from plone.app.dexterity.interfaces import IDXFileFactory
-from plone.dexterity.interfaces import IDexterityFTI
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.permissions import AddPortalContent
@@ -150,16 +149,7 @@ class FileUploadView(BrowserView):
                     "try another one"
                 )
 
-        # Determine if the default file/image types are DX or AT based
-        dx_based = False
-        pt = getToolByName(self.context, 'portal_types')
-        if IDexterityFTI.providedBy(getattr(pt, type_)):
-            factory = IDXFileFactory(self.context)
-            dx_based = True
-        else:
-            from Products.ATContentTypes.interfaces import IATCTFileFactory
-            factory = IATCTFileFactory(self.context)
-
+        factory = IDXFileFactory(self.context)
         obj = factory(filename, content_type, filedata)
 
         result = {
@@ -167,19 +157,12 @@ class FileUploadView(BrowserView):
             "size": 0
         }
 
-        if dx_based:
-            if 'File' in obj.portal_type:
-                result['size'] = obj.file.getSize()
-                result['type'] = obj.file.contentType
-            elif 'Image' in obj.portal_type:
-                result['size'] = obj.image.getSize()
-                result['type'] = obj.image.contentType
-        else:
-            result['type'] = obj.getContentType()
-            try:
-                result['size'] = obj.getSize()
-            except AttributeError:
-                result['size'] = obj.get_size()
+        if 'File' in obj.portal_type:
+            result['size'] = obj.file.getSize()
+            result['type'] = obj.file.contentType
+        elif 'Image' in obj.portal_type:
+            result['size'] = obj.image.getSize()
+            result['type'] = obj.image.contentType
 
         if tusrequest:
             tus.cleanup_file()

--- a/plone/app/content/browser/folderfactories.py
+++ b/plone/app/content/browser/folderfactories.py
@@ -8,7 +8,7 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize.instance import memoize
 from plone.memoize.request import memoize_diy_request
 from plone.protect.authenticator import createToken
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 from zope.component import getMultiAdapter
 from zope.component import queryUtility
 from zope.i18n import translate

--- a/plone/app/content/browser/reviewlist.py
+++ b/plone/app/content/browser/reviewlist.py
@@ -54,8 +54,6 @@ class ReviewListTable:
         portal_url = getToolByName(self.context, 'portal_url')
         plone_view = getMultiAdapter((self.context, self.request),
                                      name='plone')
-        plone_layout = getMultiAdapter((self.context, self.request),
-                                       name='plone_layout')
         portal_workflow = getToolByName(self.context, 'portal_workflow')
         portal_types = getToolByName(self.context, 'portal_types')
         portal_membership = getToolByName(self.context, 'portal_membership')

--- a/plone/app/content/browser/reviewlist.py
+++ b/plone/app/content/browser/reviewlist.py
@@ -6,7 +6,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import human_readable_size
 from Products.CMFPlone.utils import isExpired
 from Products.CMFPlone.utils import safe_unicode
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.i18n import translate

--- a/plone/app/content/browser/tableview.py
+++ b/plone/app/content/browser/tableview.py
@@ -3,7 +3,7 @@ from plone.batching.browser import BatchView
 from plone.memoize import instance
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 from zope.i18nmessageid import MessageFactory
 from zope.publisher.browser import BrowserView
 from ZTUtils import make_query

--- a/plone/app/content/browser/templates/select_default_page.pt
+++ b/plone/app/content/browser/templates/select_default_page.pt
@@ -60,7 +60,7 @@
                        value="Save"
                        i18n:attributes="value label_save;"
                        />
-                <input 
+                <input
                        type="submit"
                        name="form.buttons.Cancel"
                        value="Cancel"

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -348,9 +348,9 @@ class VocabularyView(BaseVocabularyView):
         # which take the (unparsed) query as a parameter of the vocab
         # factory rather than as a separate search method.
         if isinstance(factory, FunctionType):
-            factory_spec = inspect.getargspec(factory)
+            factory_spec = inspect.getfullargspec(factory)
         else:
-            factory_spec = inspect.getargspec(factory.__call__)
+            factory_spec = inspect.getfullargspec(factory.__call__)
         query = _parseJSON(self.request.get('query', ''))
         if query and 'query' in factory_spec.args:
             vocabulary = factory(context, query=query)

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -28,7 +28,6 @@ from zope.security.interfaces import IPermission
 
 import inspect
 import itertools
-import six
 
 
 logger = getLogger(__name__)

--- a/plone/app/content/container.py
+++ b/plone/app/content/container.py
@@ -7,8 +7,6 @@ from zope.container.contained import Contained
 from zope.container.interfaces import IContainer
 from zope.interface import implementer
 
-import six
-
 
 @implementer(IContainer)
 class OFSContainer:
@@ -38,8 +36,6 @@ class OFSContainer:
     # __getitem__ is already implemented by ObjectManager
 
     def __setitem__(self, name, obj):
-        if six.PY2 and isinstance(name, str):
-            name = name.encode('ascii')  # may raise if there's a bugus id
         self._setObject(name, obj)
 
     def __delitem__(self, name):

--- a/plone/app/content/namechooser.py
+++ b/plone/app/content/namechooser.py
@@ -4,7 +4,6 @@ from plone.app.content.interfaces import INameFromTitle
 from plone.i18n.normalizer import FILENAME_REGEX
 from plone.i18n.normalizer.interfaces import IURLNormalizer
 from plone.i18n.normalizer.interfaces import IUserPreferredURLNormalizer
-from zExceptions import BadRequest
 from zope.component import getUtility
 from zope.container.interfaces import INameChooser
 from zope.interface import implementer
@@ -105,19 +104,9 @@ class NormalizingNameChooser:
                     contained_by=parent
                 )
 
-            # Function in CMFPlone added in 5.1.4/5,
-            # which replaces the skin script that will be removed in 5.2.
-            try:
-                from Products.CMFPlone.utils import check_id
-                return check_id(
-                    obj, newid, required=required, contained_by=parent)
-            except ImportError:
-                pass
+            from Products.CMFPlone.utils import check_id
 
-            # fallback to OFS
-            try:
-                parent._checkId(newid)
-            except BadRequest:
-                return True
+            return check_id(
+                obj, newid, required=required, contained_by=parent)
 
         return do_Plone_check

--- a/plone/app/content/namechooser.py
+++ b/plone/app/content/namechooser.py
@@ -9,7 +9,6 @@ from zope.component import getUtility
 from zope.container.interfaces import INameChooser
 from zope.interface import implementer
 
-import six
 import time
 
 

--- a/plone/app/content/namechooser.txt
+++ b/plone/app/content/namechooser.txt
@@ -110,26 +110,6 @@ When a filename is used as an id, the extension is preserved.
     >>> chooser.checkName(name, object)
     True
 
-If the chooser is used with a container that implements the
-IObjectManager interface from OFS, the checkValidId method
-of that interface will be used to check for validity of the
-chosen name. This catches various edge cases.
-We need to force an ImportError for the check_id function in Plone.
-
-    >>> from OFS.ObjectManager import ObjectManager
-    >>> om = ObjectManager()
-    >>> om.title = 'foo'
-    >>> alsoProvides(om, IFolderish)
-    >>> chooser2 = INameChooser(om)
-    >>> from Products.CMFPlone import utils
-    >>> orig_check_id = utils.check_id
-    >>> def dummy_check_id(*args, **kwargs):
-    ...     raise ImportError
-    >>> utils.check_id = dummy_check_id
-    >>> chooser2.chooseName('title', item)
-    'title-1'
-    >>> utils.check_id = orig_check_id
-
 
 Choosing names based on type
 ----------------------------

--- a/plone/app/content/testing.py
+++ b/plone/app/content/testing.py
@@ -4,7 +4,6 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.testing import zope
 from Products.CMFCore.utils import getToolByName
 from zope.configuration import xmlconfig
 from zope.interface import implementer

--- a/plone/app/content/testing.py
+++ b/plone/app/content/testing.py
@@ -4,7 +4,7 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.testing import z2
+from plone.testing import zope
 from Products.CMFCore.utils import getToolByName
 from zope.configuration import xmlconfig
 from zope.interface import implementer

--- a/plone/app/content/testing.py
+++ b/plone/app/content/testing.py
@@ -15,12 +15,6 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 import doctest
 
-try:
-    import Products.Archetypes
-    HAS_AT= True
-except ImportError:
-    HAS_AT = False
-
 
 @implementer(IVocabularyFactory)
 class ExampleVocabulary:
@@ -121,22 +115,6 @@ class NonAsciiLayer(PloneSandboxLayer):
         applyProfile(portal, 'plone.app.content.tests:non-ascii-workflow')
 
 
-if HAS_AT:
-    class PloneAppContentAT(PloneAppContent):
-
-        def setUpZope(self, app, configurationContext):
-            super().setUpZope(app, configurationContext)
-            import Products.ATContentTypes
-            xmlconfig.file('configure.zcml',
-                           Products.ATContentTypes,
-                           context=configurationContext)
-            z2.installProduct(app, 'Products.ATContentTypes')
-
-        def setUpPloneSite(self, portal):
-            super().setUpPloneSite(portal)
-            self.applyProfile(portal, 'Products.ATContentTypes:default')
-
-
 PLONE_APP_CONTENT_FIXTURE = PloneAppContent()
 PLONE_APP_CONTENT_INTEGRATION_TESTING = IntegrationTesting(
     bases=(PLONE_APP_CONTENT_FIXTURE, ),
@@ -160,17 +138,6 @@ PLONE_APP_CONTENT_NON_ASCII_LAYER = NonAsciiLayer()
 PLONE_APP_CONTENT_NON_ASCII_INTEGRATION_TESTING = IntegrationTesting(
     bases=(PLONE_APP_CONTENT_NON_ASCII_LAYER, ),
     name="PloneAppContentNonAscii:Integration")
-
-
-if HAS_AT:
-    # AT test layers
-    PLONE_APP_CONTENT_AT_FIXTURE = PloneAppContentAT()
-    PLONE_APP_CONTENT_AT_INTEGRATION_TESTING = IntegrationTesting(
-        bases=(PLONE_APP_CONTENT_AT_FIXTURE, ),
-        name="PloneAppContentAT:Integration")
-    PLONE_APP_CONTENT_AT_FUNCTIONAL_TESTING = FunctionalTesting(
-        bases=(PLONE_APP_CONTENT_AT_FIXTURE, ),
-        name="PloneAppContentAT:Functional")
 
 
 optionflags = (

--- a/plone/app/content/tests/test_actions.py
+++ b/plone/app/content/tests/test_actions.py
@@ -4,7 +4,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import logout
 from plone.app.testing import setRoles
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from plone.locking.interfaces import ILockable
 from zExceptions import Unauthorized
 from z3c.form.interfaces import IFormLayer

--- a/plone/app/content/tests/test_actions.py
+++ b/plone/app/content/tests/test_actions.py
@@ -1,4 +1,3 @@
-from plone.app.content.testing import HAS_AT
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -15,8 +14,7 @@ from zope.interface import alsoProvides
 import transaction
 import unittest
 
-if HAS_AT:
-    from plone.app.content.testing import PLONE_APP_CONTENT_AT_FUNCTIONAL_TESTING
+
 
 class ActionsDXTestCase(unittest.TestCase):
 
@@ -446,9 +444,3 @@ class ActionsDXTestCase(unittest.TestCase):
         self.assertIn('copy_of_d1', folder.objectIds())
         self.assertIn('copy2_of_d1', folder.objectIds())
         self.assertIn('Item(s) pasted.', self.browser.contents)
-
-
-if HAS_AT:
-    class ActionsATTestCase(ActionsDXTestCase):
-
-        layer = PLONE_APP_CONTENT_AT_FUNCTIONAL_TESTING

--- a/plone/app/content/tests/test_contents.py
+++ b/plone/app/content/tests/test_contents.py
@@ -11,7 +11,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.dexterity.fti import DexterityFTI
 from plone.protect.authenticator import createToken
 from plone.registry.interfaces import IRegistry
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from plone.uuid.interfaces import IUUID
 from unittest import mock
 from zope.component import getMultiAdapter

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -10,7 +10,7 @@ from plone.locking.interfaces import IRefreshableLockable
 from plone.protect.authenticator import createToken
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from Testing.makerequest import makerequest
 from transaction import commit
 from zope.annotation.interfaces import IAttributeAnnotatable

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -1,5 +1,4 @@
 from DateTime import DateTime
-from plone.app.content.testing import HAS_AT
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
 from plone.app.testing import login
@@ -20,9 +19,6 @@ from zope.publisher.browser import TestRequest
 
 import json
 import unittest
-
-if HAS_AT:
-    from plone.app.content.testing import PLONE_APP_CONTENT_AT_INTEGRATION_TESTING
 
 
 class BaseTest(unittest.TestCase):
@@ -115,56 +111,6 @@ class PropertiesDXTest(DXBaseTest):
             self.portal.page.creators,
             ('one', 'two')
         )
-
-if HAS_AT:
-    class PropertiesArchetypesTest(BaseTest):
-        layer = PLONE_APP_CONTENT_AT_INTEGRATION_TESTING
-
-        def testExcludeFromNav(self):
-            from plone.app.content.browser.contents.properties import PropertiesActionView  # noqa
-            self.request.form['exclude-from-nav'] = 'yes'
-            view = PropertiesActionView(self.portal.page, self.request)
-            view()
-            self.assertEqual(self.portal.page.getExcludeFromNav(), True)
-
-        def testEffective(self):
-            from plone.app.content.browser.contents.properties import PropertiesActionView  # noqa
-            self.request.form['effectiveDate'] = '1999/01/01 09:00'
-            view = PropertiesActionView(self.portal.page, self.request)
-            view()
-            self.assertEqual(
-                DateTime(self.portal.page.EffectiveDate()).toZone('UTC'),
-                DateTime('1999/01/01 09:00').toZone('UTC'))
-
-        def testExpires(self):
-            from plone.app.content.browser.contents.properties import PropertiesActionView  # noqa
-            self.request.form['expirationDate'] = '1999/01/01 09:00'
-            view = PropertiesActionView(self.portal.page, self.request)
-            view()
-            self.assertEqual(
-                DateTime(self.portal.page.ExpirationDate()).toZone('UTC'),
-                DateTime('1999/01/01 09:00').toZone('UTC'))
-
-        def testRights(self):
-            from plone.app.content.browser.contents.properties import PropertiesActionView  # noqa
-            self.request.form['copyright'] = 'foobar'
-            view = PropertiesActionView(self.portal.page, self.request)
-            view()
-            self.assertEqual(self.portal.page.Rights(), 'foobar')
-
-        def testContributors(self):
-            from plone.app.content.browser.contents.properties import PropertiesActionView  # noqa
-            self.request.form['contributors'] = self.userList
-            view = PropertiesActionView(self.portal.page, self.request)
-            view()
-            self.assertEqual(self.portal.page.Contributors(), ('one', 'two'))
-
-        def testCreators(self):
-            from plone.app.content.browser.contents.properties import PropertiesActionView  # noqa
-            self.request.form['creators'] = self.userList
-            view = PropertiesActionView(self.portal.page, self.request)
-            view()
-            self.assertEqual(self.portal.page.Creators(), ('one', 'two'))
 
 
 class WorkflowTest(BaseTest):
@@ -370,12 +316,6 @@ class DeleteDXTest(BaseTest):
         self.assertFalse(p1 in self.portal[f1])
 
 
-if HAS_AT:
-    class DeleteATTest(DeleteDXTest):
-
-        layer = PLONE_APP_CONTENT_AT_INTEGRATION_TESTING
-
-
 class RearrangeDXTest(BaseTest):
     """Verify rearrange feature from the folder contents view"""
 
@@ -543,11 +483,6 @@ class RearrangeDXTest(BaseTest):
                 ('page_2', 'Page 2'),
             ]
         )
-
-if HAS_AT:
-    class RearrangeATTest(RearrangeDXTest):
-
-        layer = PLONE_APP_CONTENT_AT_INTEGRATION_TESTING
 
 
 class FolderFactoriesTest(unittest.TestCase):

--- a/plone/app/content/tests/test_folder.py
+++ b/plone/app/content/tests/test_folder.py
@@ -139,7 +139,7 @@ class WorkflowTest(BaseTest):
         pc = getToolByName(self.portal, "portal_catalog")
         # i need to call it, to populate catalog indexes
         pc()
-        self.assertEquals(
+        self.assertEqual(
             pc.uniqueValuesFor('effective'),
             (default_effective_index,))
         view = WorkflowActionView(self.portal.page, self.request)
@@ -153,7 +153,7 @@ class WorkflowTest(BaseTest):
         effective_index = self.convertDateTimeToIndexRepr(
             self.portal.page.effective_date
         )
-        self.assertEquals(
+        self.assertEqual(
             pc.uniqueValuesFor('effective'),
             (effective_index,))
 

--- a/plone/app/content/tests/test_folder_publish.py
+++ b/plone/app/content/tests/test_folder_publish.py
@@ -59,7 +59,7 @@ class TestContentPublishing(unittest.TestCase):
         return view(**kwargs)
 
     def test_initial_state(self):
-        # Depending on Plone version, dexterity, archetypes,
+        # Depending on the Plone version,
         # the review state may be visible or private.  Check which one it is.
         for o in (self.folder.d1, self.folder.f1, self.folder.f1.d2, self.folder.f1.f2):
             self.assertEqual(self.workflow.getInfoFor(o, "review_state"), "private")

--- a/plone/app/content/tests/test_folder_publish.py
+++ b/plone/app/content/tests/test_folder_publish.py
@@ -1,6 +1,5 @@
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_INTEGRATION_TESTING
 from plone.app.testing import login
-from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME

--- a/plone/app/content/tests/test_reviewlist.py
+++ b/plone/app/content/tests/test_reviewlist.py
@@ -1,6 +1,6 @@
 from Products.CMFCore.utils import getToolByName
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 

--- a/plone/app/content/tests/test_selectdefaultpage.py
+++ b/plone/app/content/tests/test_selectdefaultpage.py
@@ -1,4 +1,3 @@
-from plone.app.content.testing import HAS_AT
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
@@ -6,8 +5,6 @@ from plone.testing.z2 import Browser
 import transaction
 import unittest
 
-if HAS_AT:
-    from plone.app.content.testing import PLONE_APP_CONTENT_AT_FUNCTIONAL_TESTING
 
 FOLDER = {'id': 'testfolder',
           'title': 'Test Folder',
@@ -132,10 +129,3 @@ class SelectDefaultPageDXTestCase(unittest.TestCase):
         view = folder.restrictedTraverse('@@select_default_page')()
         self.assertTrue('id="testdoc"' not in view)
         self.assertTrue('id="testnews"' in view)
-
-
-
-if HAS_AT:
-    class SelectDefaultPageATTestCase(SelectDefaultPageDXTestCase):
-
-        layer = PLONE_APP_CONTENT_AT_FUNCTIONAL_TESTING

--- a/plone/app/content/tests/test_selectdefaultpage.py
+++ b/plone/app/content/tests/test_selectdefaultpage.py
@@ -1,7 +1,7 @@
 from plone.app.content.testing import PLONE_APP_CONTENT_DX_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 import transaction
 import unittest
 

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -12,6 +12,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.z3cform.interfaces import IFieldPermissionChecker
+from Products.CMFCore.indexing import processQueue
 from unittest import mock
 from zope.component import getMultiAdapter
 from zope.component import provideAdapter
@@ -27,13 +28,6 @@ import json
 import os
 import transaction
 import unittest
-
-
-try:
-    from Products.CMFCore.indexing import processQueue
-except ImportError:
-    def processQueue():
-        pass
 
 
 _dir = os.path.dirname(__file__)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
         'zope.lifecycleevent',
         'zope.publisher',
         'zope.schema',
-        'Zope2',
+        'Zope',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'plone.app.vocabularies>4.1.2',
         'setuptools',
         'simplejson',
-        'six',
         'zope.component',
         'zope.container',
         'zope.event',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'six',
         'zope.component',
         'zope.container',
-        'zope.deferredimport',
         'zope.event',
         'zope.i18n',
         'zope.i18nmessageid',


### PR DESCRIPTION
Note that master is already only used on Plone 6, so we can safely cleanup.
This removes Archetypes, fixes deprecation warnings, removes six, removes no longer needed compatibility imports, and fixes a few flake8 warnings. (The remaining flake8 warnings could be fixed by calling `black`.)

If the diff is too large, you can look at the individual commits, most of which are small.