### PR TITLE
Fix permission checks for the @@getSource view (Plone 5.2)

### DIFF
--- a/news/221.bugfix
+++ b/news/221.bugfix
@@ -1,0 +1,1 @@
+Allow to use the @@getSource view when we are in an add form and we do not have the "Modify portal content" permission

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -9,6 +9,7 @@ from plone.app.layout.navigation.root import getNavigationRoot
 from plone.app.querystring import queryparser
 from plone.app.z3cform.interfaces import IFieldPermissionChecker
 from plone.autoform.interfaces import WRITE_PERMISSIONS_KEY
+from plone.memoize.view import memoize
 from plone.supermodel.utils import mergedTaggedValueDict
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
@@ -17,6 +18,7 @@ from Products.Five import BrowserView
 from Products.MimetypesRegistry.MimeTypeItem import guess_icon_path
 from Products.MimetypesRegistry.MimeTypeItem import PREFIX
 from types import FunctionType
+from z3c.form.interfaces import IAddForm
 from z3c.form.interfaces import ISubForm
 from zope.component import getUtility
 from zope.component import queryAdapter
@@ -373,19 +375,23 @@ class SourceView(BaseVocabularyView):
             context = self.context.context
         return context
 
+    @property
+    @memoize
+    def default_permission(self):
+        if IAddForm.providedBy(self.context.form):
+            return "cmf.AddPortalContent"
+        return "cmf.ModifyPortalContent"
+
     def get_vocabulary(self):
         widget = self.context
         field = widget.field.bind(widget.context)
 
         # check field's write permission
         info = mergedTaggedValueDict(field.interface, WRITE_PERMISSIONS_KEY)
-        permission_name = info.get(field.__name__, 'cmf.ModifyPortalContent')
+        permission_name = info.get(field.__name__, self.default_permission)
         permission = queryUtility(IPermission, name=permission_name)
         if permission is None:
-            permission = getUtility(
-                IPermission,
-                name='cmf.ModifyPortalContent'
-            )
+            permission = getUtility(IPermission, name=self.default_permission)
         if not getSecurityManager().checkPermission(
             permission.title,
             self.get_context()

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -496,6 +496,25 @@ class BrowserTest(unittest.TestCase):
         data = json.loads(view())
         self.assertEqual(data['error'], 'Vocabulary lookup not allowed.')
 
+    def testSourceDefaultPermission(self):
+        from plone.app.content.browser.vocabulary import SourceView
+        from z3c.form.browser.text import TextWidget
+
+        widget = TextWidget(self.request)
+        view = SourceView(widget, self.request)
+        self.assertEqual(view.default_permission, "cmf.ModifyPortalContent")
+
+    def testSourceDefaultPermissionOnAddForm(self):
+        from plone.app.content.browser.vocabulary import SourceView
+        from z3c.form import form
+        from z3c.form.browser.text import TextWidget
+
+        widget = TextWidget(self.request)
+        widget.form = form.AddForm(self.portal, self.request)
+
+        view = SourceView(widget, self.request)
+        self.assertEqual(view.default_permission, "cmf.AddPortalContent")
+
     def testSourceTextQuery(self):
         from z3c.form.browser.text import TextWidget
         from zope.interface import implementer

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'setuptools',
         'simplejson',
         'six',
+        'z3c.form',
         'zope.component',
         'zope.container',
         'zope.deferredimport',


### PR DESCRIPTION
Allow to use the `@@getSource` view when we are in an add form and we do not have the "Modify portal content" permission

Refs #221