### PR TITLE
Fix permission checks for the @@getSource view (Plone 6)

### DIFF
--- a/news/221.bugfix
+++ b/news/221.bugfix
@@ -1,0 +1,1 @@
+Allow to use the @@getSource view when we are in an add form and we do not have the "Modify portal content" permission

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -479,6 +479,25 @@ class BrowserTest(unittest.TestCase):
         data = json.loads(view())
         self.assertEqual(data['error'], 'Vocabulary lookup not allowed.')
 
+    def testSourceDefaultPermission(self):
+        from plone.app.content.browser.vocabulary import SourceView
+        from z3c.form.browser.text import TextWidget
+
+        widget = TextWidget(self.request)
+        view = SourceView(widget, self.request)
+        self.assertEqual(view.default_permission, "cmf.ModifyPortalContent")
+
+    def testSourceDefaultPermissionOnAddForm(self):
+        from plone.app.content.browser.vocabulary import SourceView
+        from z3c.form import form
+        from z3c.form.browser.text import TextWidget
+
+        widget = TextWidget(self.request)
+        widget.form = form.AddForm(self.portal, self.request)
+
+        view = SourceView(widget, self.request)
+        self.assertEqual(view.default_permission, "cmf.AddPortalContent")
+
     def testSourceTextQuery(self):
         from z3c.form.browser.text import TextWidget
         from zope.interface import implementer

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'plone.app.vocabularies>4.1.2',
         'setuptools',
         'simplejson',
+        'z3c.form',
         'zope.component',
         'zope.container',
         'zope.event',


### PR DESCRIPTION
Allow to use the `@@getSource` view when we are in an add form and we do
not have the "Modify portal content" permission

Fixes #221