### PR TITLE
update i18n domain to be plone

### DIFF
--- a/news/234.bugfix
+++ b/news/234.bugfix
@@ -1,0 +1,1 @@
+Use plone as translation domain [erral]

--- a/plone/app/content/browser/constraintypes.py
+++ b/plone/app/content/browser/constraintypes.py
@@ -27,16 +27,16 @@ def ST(key, title):
 
 
 # reuse the translations that we had in atcontenttypes
-AMF = MessageFactory("atcontenttypes")
+_ = MessageFactory("plone")
 
 possible_constrain_types = SimpleVocabulary(
     [
         ST(
             ACQUIRE,
-            AMF("constraintypes_acquire_label", default="Use parent folder settings"),
+            _("constraintypes_acquire_label", default="Use parent folder settings"),
         ),
-        ST(DISABLED, AMF("constraintypes_disable_label", default="Use portal default")),
-        ST(ENABLED, AMF("constraintypes_enable_label", default="Select manually")),
+        ST(DISABLED, _("constraintypes_disable_label", default="Use portal default")),
+        ST(ENABLED, _("constraintypes_enable_label", default="Select manually")),
     ]
 )
 


### PR DESCRIPTION
Used translations have been merged into plone domain as part of https://github.com/collective/plone.app.locales/pull/331