### PR TITLE
Allow access to content_status_modify page for all with View permission.

### DIFF
--- a/news/3338.bugfix
+++ b/news/3338.bugfix
@@ -1,0 +1,5 @@
+Allow access to content_status_modify page for all with View permission.
+This was the case when it was still a skin script.
+The internal logic of the page makes sure you can only *really* change anything when you have the proper permission.
+Fixes `issue 3338 <https://github.com/plone/Products.CMFPlone/issues/3338>`_, where an Editor could no longer submit a page.
+[maurits]

--- a/plone/app/content/browser/configure.zcml
+++ b/plone/app/content/browser/configure.zcml
@@ -48,7 +48,7 @@
         for="*"
         name="content_status_modify"
         class=".content_status_modify.ContentStatusModifyView"
-        permission="cmf.ReviewPortalContent"
+        permission="zope2.View"
         />
 
     <!-- Folder factories -->

--- a/plone/app/content/tests/test_content_status_modify.py
+++ b/plone/app/content/tests/test_content_status_modify.py
@@ -94,3 +94,21 @@ class TestContentStatusModify(unittest.TestCase):
         view = self.get_content_status_modify_view(self.folder.d1)
         view(workflow_action="publish")
         self.assertFalse(isExpired(self.folder.d1))
+
+    def testEditorCanSubmitButNotPublish(self):
+        setRoles(self.portal, TEST_USER_ID, ["Contributor"])
+        self.folder.invokeFactory("Document", id="d2", title="Doc 2")
+        view = self.get_content_status_modify_view(self.folder.d2)
+        view(workflow_action="submit")
+        self.assertEqual(
+            self.workflow.getInfoFor(self.folder.d2, "review_state"), "pending"
+        )
+
+        # Now try publishing.
+        # For various reasons, there are no complaints/errors when trying
+        # a transition that you are not allowed to do.
+        view = self.get_content_status_modify_view(self.folder.d2)
+        view(workflow_action="publish")
+        self.assertEqual(
+            self.workflow.getInfoFor(self.folder.d2, "review_state"), "pending"
+        )


### PR DESCRIPTION
This was the case when it was still a skin script.
The internal logic of the page makes sure you can only *really* change anything when you have the proper permission.

Fixes https://github.com/plone/Products.CMFPlone/issues/3338, where an Editor could no longer submit a page.