### PR TITLE
Fix dxsiteroot vocabulary permission check

### DIFF
--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -1,8 +1,8 @@
-import itertools
-from logging import getLogger
-
 from AccessControl import getSecurityManager
 from Acquisition import aq_base
+from logging import getLogger
+from plone.app.content.utils import json_dumps
+from plone.app.content.utils import json_loads
 from plone.app.layout.navigation.root import getNavigationRoot
 from plone.app.querystring import queryparser
 from plone.app.z3cform.interfaces import IFieldPermissionChecker
@@ -13,16 +13,21 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
-from Products.MimetypesRegistry.MimeTypeItem import PREFIX, guess_icon_path
+from Products.MimetypesRegistry.MimeTypeItem import guess_icon_path
+from Products.MimetypesRegistry.MimeTypeItem import PREFIX
 from Products.PortalTransforms.transforms.safe_html import SafeHTML
-from z3c.form.interfaces import IAddForm, ISubForm
-from zope.component import getUtility, queryUtility
+from z3c.form.interfaces import IAddForm
+from z3c.form.interfaces import ISubForm
+from zope.component import getUtility
+from zope.component import queryUtility
 from zope.deprecation import deprecated
 from zope.i18n import translate
-from zope.schema.interfaces import ICollection, IVocabularyFactory
+from zope.schema.interfaces import ICollection
+from zope.schema.interfaces import IVocabularyFactory
 from zope.security.interfaces import IPermission
 
-from plone.app.content.utils import json_dumps, json_loads
+import itertools
+
 
 logger = getLogger(__name__)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [bdist_wheel]
 universal = 1
+
+[isort]
+# black compatible Plone isort rules:
+profile = black
+force_alphabetical_sort = True
+force_single_line = True
+lines_after_imports = 2


### PR DESCRIPTION
I had strange behaviors with DX site root and vocabularies with permission. Mainly because of a even before questionable use of Navigation-root specialties. This simplifies the code and defines a clear policy, That said I even would not do a field permission check here. First, it can not be weaker than the primary permission. And with the "field" parameter it is accessible anyway then. Second the field would not render if the permission would not apply. 