### PR TITLE
Fix TypeError: 'NoneType' object is not subscriptable [5.2]

### DIFF
--- a/news/2921.bugfix
+++ b/news/2921.bugfix
@@ -1,0 +1,2 @@
+Fix TypeError: 'NoneType' object is not subscriptable in reference browser widget.
+[maurits]

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -243,7 +243,7 @@ class BaseVocabularyView(BrowserView):
                             val = val()
                         else:
                             continue
-                    if key == 'path':
+                    if key == 'path' and val is not None:
                         val = val[len(base_path):]
                     if (
                         key not in translate_ignored and


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2921 for 5.2.