### PR TITLE
Require 'List folder contents' permission to use the catalog vocabulary.

### DIFF
--- a/news/261.bugfix
+++ b/news/261.bugfix
@@ -1,0 +1,3 @@
+Require ``List folder contents`` permission to use the catalog vocabulary.
+Until now ``View`` was enough, but that is not strictly correct.
+[maurits]

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -40,7 +40,7 @@ MAX_BATCH_SIZE = 500  # prevent overloading server
 DEFAULT_PERMISSION = "View"
 DEFAULT_PERMISSION_SECURE = "Modify portal content"
 PERMISSIONS = {
-    "plone.app.vocabularies.Catalog": "View",
+    "plone.app.vocabularies.Catalog": "List folder contents",
     "plone.app.vocabularies.Keywords": "Modify portal content",
     "plone.app.vocabularies.SyndicatableFeedItems": "Modify portal content",
     "plone.app.vocabularies.Users": "Modify portal content",


### PR DESCRIPTION
This is more correct than the View permission.