### PR TITLE
Fix escaped html entities in vocabulary items

### DIFF
--- a/news/3874.bugfix
+++ b/news/3874.bugfix
@@ -1,0 +1,2 @@
+Fix html escaped entities in vocabulary items.
+[petschki]

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -260,8 +260,8 @@ class BaseVocabularyView(BrowserView):
         else:
             items = [
                 {
-                    "id": transform.scrub_html(item.value),
-                    "text": transform.scrub_html(item.title) if item.title else "",
+                    "id": transform.scrub_html(item.value).replace("&amp;", "&"),
+                    "text": transform.scrub_html(item.title).replace("&amp;", "&") if item.title else "",
                 }
                 for item in results
             ]

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -1,5 +1,6 @@
 from AccessControl import getSecurityManager
 from Acquisition import aq_base
+from html import unescape
 from logging import getLogger
 from plone.app.content.utils import json_dumps
 from plone.app.content.utils import json_loads
@@ -260,8 +261,10 @@ class BaseVocabularyView(BrowserView):
         else:
             items = [
                 {
-                    "id": transform.scrub_html(item.value).replace("&amp;", "&"),
-                    "text": transform.scrub_html(item.title).replace("&amp;", "&") if item.title else "",
+                    "id": unescape(transform.scrub_html(item.value)),
+                    "text": unescape(transform.scrub_html(item.title))
+                    if item.title
+                    else "",
                 }
                 for item in results
             ]

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -269,6 +269,25 @@ class BrowserTest(unittest.TestCase):
         self.assertEqual(result["text"], test_val)
         self.assertEqual(result["id"], test_val)
 
+    def testVocabularyHtmlEntity(self):
+        """ The vocabulary token should not convert to htmlentities.
+        See https://github.com/plone/Products.CMFPlone/issues/3874
+        """
+        test_val = "Question & Answer"
+
+        self.portal.invokeFactory("Document", id="page", title="page")
+        self.portal.page.subject = (test_val,)
+        self.portal.page.reindexObject(idxs=["Subject"])
+        processQueue()
+
+        self.request.form["name"] = "plone.app.vocabularies.Keywords"
+        results = getMultiAdapter((self.portal, self.request), name="getVocabulary")()
+        results = json.loads(results)
+        result = results["results"][0]
+
+        self.assertEqual(result["text"], test_val)
+        self.assertEqual(result["id"], test_val)
+
     def testVocabularyUnauthorized(self):
         setRoles(self.portal, TEST_USER_ID, [])
         view = VocabularyView(self.portal, self.request)

--- a/plone/app/content/tests/test_widgets.py
+++ b/plone/app/content/tests/test_widgets.py
@@ -270,7 +270,7 @@ class BrowserTest(unittest.TestCase):
         self.assertEqual(result["id"], test_val)
 
     def testVocabularyHtmlEntity(self):
-        """ The vocabulary token should not convert to htmlentities.
+        """The vocabulary token should not convert to htmlentities.
         See https://github.com/plone/Products.CMFPlone/issues/3874
         """
         test_val = "Question & Answer"


### PR DESCRIPTION
see https://github.com/plone/Products.CMFPlone/issues/3874

I tried to change the `parser` here https://github.com/plone/Products.PortalTransforms/blob/master/Products/PortalTransforms/transforms/safe_html.py#L187 to `html.XHTMLParser(encoding="utf-8", resolve_entities=False, recover=True)` but this removes all entities in the string and leads to many testing failures.

Note that this only affects `@@getVocabulary` BrowserView when no attributes are passed in the request ~~and for this special `&` case. Wonder if there is a more generic solution for more cases out there?~~ Update: I think its ok to unescape all entities.