### PR TITLE
No longer check visible_ids on the 'select default page' form.

### DIFF
--- a/news/125.bugfix
+++ b/news/125.bugfix
@@ -1,0 +1,4 @@
+No longer check ``visible_ids`` on the 'select default page' form.
+Usage of ``visible_ids`` was largely removed in Plone 5.0 already, and you cannot change the setting on the portal or the member.
+This was using the deprecated ``portal_properties`` tool.
+[maurits]

--- a/plone/app/content/browser/templates/select_default_page.pt
+++ b/plone/app/content/browser/templates/select_default_page.pt
@@ -46,9 +46,6 @@
                      ">
             <tal:hasitems define="
                             n_items python:len(items);
-                            member portal_state/member;
-                            portal_visible_ids context/portal_properties/site_properties/visible_ids|nothing;
-                            member_visible_ids python:member.getProperty('visible_ids', context.portal_memberdata.getProperty('visible_ids'));
                           "
                           condition="items"
             >
@@ -56,7 +53,6 @@
                 <tal:item repeat="item items">
                   <dt tal:define="
                         normalized_type python:plone_view.normalizeString(item.portal_type);
-                        item_id python:'(%s)' % item.getId if (portal_visible_ids and member_visible_ids) else '';
                       ">
                     <input name="objectId"
                            type="radio"
@@ -67,7 +63,7 @@
                              checked python: (n_items==1 or item.getId==cur_page) and 'checked' or None;
                            "
                     />
-                    <label tal:content="string:${item/pretty_title_or_id} $item_id"
+                    <label tal:content="string:${item/pretty_title_or_id}"
                            tal:attributes="
                              for item/getId;
                              class string:contenttype-${normalized_type};


### PR DESCRIPTION
Usage of ``visible_ids`` was largely removed in Plone 5.0 already, and you cannot change the setting on the portal or the member. This was using the deprecated ``portal_properties`` tool. See also https://github.com/plone/plone.app.contenttypes/pull/693

I think this is fine in Plone 6.0 already.
If this part was still working, then the 'select default page' form would look like this, showing the ids in brackets.  Sorry, Dutch text:

![Screenshot 2024-06-06 at 23 34 35](https://github.com/plone/plone.app.content/assets/210587/da272087-52ba-457e-b55f-97ca4a2c6561)
