### PR TITLE
getVocabulary: Call scrub_html on the end result

### DIFF
--- a/news/287.bugfix
+++ b/news/287.bugfix
@@ -1,0 +1,1 @@
+getVocabulary: Speed improvement for large vocabularies

--- a/plone/app/content/browser/vocabulary.py
+++ b/plone/app/content/browser/vocabulary.py
@@ -261,10 +261,8 @@ class BaseVocabularyView(BrowserView):
         else:
             items = [
                 {
-                    "id": unescape(transform.scrub_html(item.value)),
-                    "text": (
-                        unescape(transform.scrub_html(item.title)) if item.title else ""
-                    ),
+                    "id": item.value,
+                    "text": (item.title if item.title else ""),
                 }
                 for item in results
             ]
@@ -272,7 +270,9 @@ class BaseVocabularyView(BrowserView):
         if total == 0:
             total = len(items)
 
-        return json_dumps({"results": items, "total": total})
+        return unescape(
+            transform.scrub_html(json_dumps({"results": items, "total": total}))
+        )
 
     def parsed_query(
         self,


### PR DESCRIPTION
… instead of individual items

This saves a lot of runtime for large vocabularies like Keywords. On a site with 30,000 keywords the request time went down from 13 seconds to under a second.