### PR TITLE
Fixes folder_constraintypes_form breaking with `no value` option being chosen

### DIFF
--- a/news/3654.bugfix
+++ b/news/3654.bugfix
@@ -1,2 +1,1 @@
-Fixed a situation where folder_constraintypes_form when choosing `No Value` option
-[rohnsha0]
+Fix error when folder content type restrictions were set to `No value`. @rohnsha0

--- a/news/3654.bugfix
+++ b/news/3654.bugfix
@@ -1,0 +1,2 @@
+Fixed a situation where folder_constraintypes_form when choosing `No Value` option
+[rohnsha0]

--- a/plone/app/content/browser/constraintypes.py
+++ b/plone/app/content/browser/constraintypes.py
@@ -68,7 +68,7 @@ class IConstrainForm(Interface):
         ),
         vocabulary=possible_constrain_types,
         required=True,
-        default = ACQUIRE
+        default=ACQUIRE,
     )
 
     allowed_types = List(

--- a/plone/app/content/browser/constraintypes.py
+++ b/plone/app/content/browser/constraintypes.py
@@ -67,7 +67,7 @@ class IConstrainForm(Interface):
             default="Select the restriction policy " "in this location",
         ),
         vocabulary=possible_constrain_types,
-        required=False,
+        required=True,
     )
 
     allowed_types = List(

--- a/plone/app/content/browser/constraintypes.py
+++ b/plone/app/content/browser/constraintypes.py
@@ -68,6 +68,7 @@ class IConstrainForm(Interface):
         ),
         vocabulary=possible_constrain_types,
         required=True,
+        default = ACQUIRE
     )
 
     allowed_types = List(


### PR DESCRIPTION
fixes [#3654](https://github.com/plone/Products.CMFPlone/issues/3654)