### PR TITLE
Fix @@allow_upload traversal when parent folders are restricted

### DIFF
--- a/news/4055.bugfix
+++ b/news/4055.bugfix
@@ -1,0 +1,2 @@
+Fix @@allow_upload failing with a 302 redirect when parent folders
+are restricted but the target folder is accessible.

--- a/news/4055.bugfix
+++ b/news/4055.bugfix
@@ -1,2 +1,1 @@
-Fix @@allow_upload failing with a 302 redirect when parent folders
-are restricted but the target folder is accessible.
+Fix @@allow_upload failing with a 302 redirect when parent folders are restricted but the target folder is accessible. @shivaansh0610-LUFFY 

--- a/src/plone/app/content/browser/file.py
+++ b/src/plone/app/content/browser/file.py
@@ -1,3 +1,4 @@
+from zope.traversing.api import unrestrictedTraverse
 from AccessControl import getSecurityManager
 from OFS.interfaces import IFolder
 from plone.app.dexterity.interfaces import IDXFileFactory
@@ -5,6 +6,7 @@ from plone.base.permissions import AddPortalContent
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
+
 
 import json
 import logging
@@ -190,7 +192,7 @@ class AllowUploadView(BrowserView):
         )
         context = self.context
         if self.request.form.get("path"):
-            context = context.restrictedTraverse(self.request.form.get("path"))
+            context = unrestrictedTraverse(context, self.request.form.get("path"))
 
         allow_images = False
         allow_files = False

--- a/src/plone/app/content/browser/file.py
+++ b/src/plone/app/content/browser/file.py
@@ -1,4 +1,3 @@
-from zope.traversing.api import unrestrictedTraverse
 from AccessControl import getSecurityManager
 from OFS.interfaces import IFolder
 from plone.app.dexterity.interfaces import IDXFileFactory
@@ -6,7 +5,7 @@ from plone.base.permissions import AddPortalContent
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
-
+from zope.traversing.api import unrestrictedTraverse
 
 import json
 import logging

--- a/src/plone/app/content/browser/file.py
+++ b/src/plone/app/content/browser/file.py
@@ -5,7 +5,6 @@ from plone.base.permissions import AddPortalContent
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
-from zope.traversing.api import unrestrictedTraverse
 
 import json
 import logging
@@ -191,7 +190,7 @@ class AllowUploadView(BrowserView):
         )
         context = self.context
         if self.request.form.get("path"):
-            context = unrestrictedTraverse(context, self.request.form.get("path"))
+            context = context.unrestrictedTraverse(self.request.form.get("path"))
 
         allow_images = False
         allow_files = False


### PR DESCRIPTION
Contributes to https://github.com/plone/Products.CMFPlone/issues/4055

When a user does not have the View or Access contents information permission
on an intermediate folder, calling @@allow_upload with a deep path
(for example, /a/b/c) resulted in a 302 redirect due to the use of
restrictedTraverse.

This change replaces restrictedTraverse with
context.unrestrictedTraverse(path) when resolving the target context,
while still relying on normal permission checks to determine the allowed
content types.

As a result, @@allow_upload works correctly even when parent folders
are restricted, as long as the target folder itself is accessible.

All tests pass.
