### PR TITLE
@@getVocabulary: Fix list of metadata attributes which should not be …

### DIFF
--- a/news/+getvocab-translate-ignored.bugfix.rst
+++ b/news/+getvocab-translate-ignored.bugfix.rst
@@ -1,0 +1,1 @@
+@@getVocabulary: Fix list of metadata attributes which should not be translated.

--- a/src/plone/app/content/browser/vocabulary.py
+++ b/src/plone/app/content/browser/vocabulary.py
@@ -84,7 +84,8 @@ TRANSLATED_IGNORED = [
     "Subject",
     "sync_uid",
     "Title",
-    "total_comments" "UID",
+    "total_comments",
+    "UID",
 ]
 
 _permissions = PERMISSIONS


### PR DESCRIPTION
…translated.

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

