### PR TITLE
 Allow the timezone vocabulary to be called from the web without special permissions.

### DIFF
--- a/src/plone/app/content/browser/contents/templates/folder_contents.pt
+++ b/src/plone/app/content/browser/contents/templates/folder_contents.pt
@@ -18,8 +18,8 @@
 <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core">
         <span tal:replace="structure context/@@authenticator/authenticator"/>
-        <div class="pat-structure"
-          tal:attributes="data-pat-structure view/options" />
+        <div class="pat-filemanager"
+          tal:attributes="data-pat-filemanager view/options" />
     </metal:content-core>
 </metal:content-core>
 

--- a/src/plone/app/content/browser/vocabulary.py
+++ b/src/plone/app/content/browser/vocabulary.py
@@ -44,6 +44,7 @@ PERMISSIONS = {
     "plone.app.vocabularies.Catalog": "View",
     "plone.app.vocabularies.Keywords": "Modify portal content",
     "plone.app.vocabularies.SyndicatableFeedItems": "Modify portal content",
+    "plone.app.vocabularies.Timezones": "View",
     "plone.app.vocabularies.Users": "Modify portal content",
     "plone.app.multilingual.RootCatalog": "View",
 }


### PR DESCRIPTION
Part of: https://github.com/plone/plone.app.z3cform/pull/267

Ref PLIP 4115: https://github.com/plone/Products.CMFPlone/issues/4115

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

